### PR TITLE
Use an IScopedHostFactory for creating scoped hosts

### DIFF
--- a/src/Vectron.Extensions.Hosting/IScopedHostFactory.cs
+++ b/src/Vectron.Extensions.Hosting/IScopedHostFactory.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Vectron.Extensions.Hosting;
+
+/// <summary>
+/// A function that will be run after the <see cref="IServiceScope"/> is created, but before the <see cref="IScopedHost"/> is started.
+/// </summary>
+/// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
+/// <param name="cancellationToken">A <see cref="CancellationToken"/> for stopping the setup.</param>
+/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+public delegate Task SetupScopeFunc(IServiceProvider serviceProvider, CancellationToken cancellationToken);
+
+/// <summary>
+/// A factory for creating and starting a scoped host.
+/// </summary>
+public interface IScopedHostFactory
+{
+    /// <summary>
+    /// Create a new <see cref="IServiceScope"/> and run the <see cref="IScopedHost"/> inside there.
+    /// </summary>
+    /// <param name="setupAction">A function that will be run after the <see cref="IServiceScope"/> is created, but before the <see cref="IScopedHost"/> is started.</param>
+    /// <param name="cancellationToken">The token to trigger shutdown.</param>
+    /// <returns>A <see cref="Task"/> that will be completed when the <see cref="IScopedHost"/> stops.</returns>
+    Task RunScopedHostAsync(SetupScopeFunc setupAction, CancellationToken cancellationToken);
+}

--- a/src/Vectron.Extensions.Hosting/Internal/ScopedHostFactory.cs
+++ b/src/Vectron.Extensions.Hosting/Internal/ScopedHostFactory.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Vectron.Extensions.Hosting.Internal;
+
+/// <summary>
+/// Default implementation of <see cref="IScopedHostFactory"/>.
+/// </summary>
+/// <param name="scopeFactory">The <see cref="IServiceScopeFactory"/>.</param>
+/// <param name="scopeLifeTime">The <see cref="IScopeLifeTime"/>.</param>
+internal class ScopedHostFactory(IServiceScopeFactory scopeFactory, IScopeLifeTime scopeLifeTime) : IScopedHostFactory
+{
+    private readonly ScopeLifeTime scopeLifeTime = scopeLifeTime as ScopeLifeTime
+        ?? throw new InvalidOperationException("Replacing IScopeLifeTime is not supported.");
+
+    /// <inheritdoc/>
+    public async Task RunScopedHostAsync(SetupScopeFunc setupAction, CancellationToken cancellationToken)
+    {
+        var scope = scopeFactory.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            await setupAction(scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            scopeLifeTime.NotifyCreated(scope);
+            cancellationToken.ThrowIfCancellationRequested();
+            var host = scope.ServiceProvider.GetRequiredService<IScopedHost>();
+            await host.RunAsync(cancellationToken).ConfigureAwait(false);
+            scopeLifeTime.NotifyDestroying(scope);
+        }
+    }
+}

--- a/src/Vectron.Extensions.Hosting/ScopedHostServiceCollectionExtensions.cs
+++ b/src/Vectron.Extensions.Hosting/ScopedHostServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class ScopedHostServiceCollectionExtensions
         services.TryAddScoped<IScopedHostLifetime, NullLifetime>();
         services.TryAddScoped<IScopedHost, ScopedHost>();
         services.TryAddSingleton<IScopeLifeTime, ScopeLifeTime>();
+        services.TryAddTransient<IScopedHostFactory, ScopedHostFactory>();
         return services;
     }
 


### PR DESCRIPTION
Using the IScopedHostFactory users don't have to injuect the IServiceProvider to start scoped hosts