### PR TITLE
Update config standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,5 @@
-# Version: 5.0.0 (Using https://semver.org/)
-# Updated: 2023-10-04
-# See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
-# See https://github.com/RehanSaeed/EditorConfig for updates to this file.
+# Version: 9.0.0 (Using https://semver.org/)
+# Updated: 2024-11-14
 # See http://EditorConfig.org for more information about .editorconfig files.
 
 ##########################################
@@ -27,6 +25,10 @@ trim_trailing_whitespace = true
 # Visual Studio Solution Files
 [*.sln]
 indent_style = tab
+
+# Visual Studio xml Solution Files
+[*.slnx]
+indent_size = 2
 
 # Visual Studio XML Project Files
 [*.{csproj,vbproj,vcxproj.filters,proj,projitems,shproj}]
@@ -64,189 +66,681 @@ end_of_line = lf
 [Makefile]
 indent_style = tab
 
+# WIX files
+[*.{wxi,wxl,wxs,wixobj}]
+indent_size = 2
+
 ##########################################
 # Visual Studio Spell Checker
 # https://learn.microsoft.com/visualstudio/ide/text-spell-checker
 ##########################################
+[*]
 
 # Note that you must have the relevant Windows language pack installed on your machine for this to work.
-spelling_languages = en-GB            # NEW
-spelling_error_severity = information # NEW
-spelling_checkable_types =            # NEW
+spelling_languages = en-us,en-gb
+spelling_error_severity = information
+spelling_checkable_types = strings,identifiers,comments
+spelling_use_default_exclusion_dictionary = true
 
 ##########################################
 # Default .NET Code Style Severities
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#scope
 ##########################################
-
 [*.{cs,csx,cake,vb,vbx}]
 
 # Default Severity for all .NET Code Style rules below
 dotnet_analyzer_diagnostic.severity = warning
 
 ##########################################
-# Language Rules - .NET
-# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
+# using directive preferences
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#using-directive-preferences
 ##########################################
-
 [*.{cs,csx,cake,vb,vbx}]
 
-# File header preferences
+# Require file header (IDE0073)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0073
+# dotnet_diagnostic.IDE0073.severity = none
 # file_header_template = <copyright file="{fileName}" company="PROJECT-AUTHOR">\n© PROJECT-AUTHOR\n</copyright>
 # If you use StyleCop, you'll need to disable SA1636: File header copyright text should match.
-# dotnet_diagnostic.SA1636.severity = none
 
+# Remove unnecessary using directives (IDE0005)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005
+# dotnet_diagnostic.IDE0005.severity = default
+
+# 'using' directive placement (IDE0065)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0065
+# dotnet_diagnostic.IDE0065.severity = default
+csharp_using_directive_placement = outside_namespace
+
+##########################################
+# Code-block preferences
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#code-block-preferences
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
+
+# Add braces (IDE0011)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0011
+# dotnet_diagnostic.IDE0011.severity = default
+csharp_prefer_braces = true
+
+# Use simple 'using' statement (IDE0063)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0063
+dotnet_diagnostic.IDE0063.severity = error
+csharp_style_prefer_simple_using_statement = true
+
+# Namespace declaration preferences (IDE0160 and IDE0161)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0160-ide0161
+# dotnet_diagnostic.IDE0160.severity = default
+# dotnet_diagnostic.IDE0161.severity = default
+csharp_style_namespace_declarations = file_scoped
+
+# Remove unnecessary lambda expression (IDE0200)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0200
+# dotnet_diagnostic.IDE0200.severity = default
+csharp_style_prefer_method_group_conversion = true
+
+# Convert to top-level statements (IDE0210)
+# Convert to 'Program.Main' style program (IDE0211)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0210
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0211
+# dotnet_diagnostic.IDE0210.severity = default
+# dotnet_diagnostic.IDE0211.severity = default
+csharp_style_prefer_top_level_statements = true
+
+# Use primary constructor (IDE0290)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0290
+# dotnet_diagnostic.IDE0290.severity = default
+csharp_style_prefer_primary_constructors = true
+
+# Prefer 'System.Threading.Lock' (IDE0330)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0330
+# dotnet_diagnostic.IDE0330.severity = default
+csharp_prefer_system_threading_lock = true
+
+##########################################
+# Expression-bodied members
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#expression-bodied-members
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
+
+# Use expression body for constructors (IDE0021)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0021
+# dotnet_diagnostic.IDE0021.severity = default
+csharp_style_expression_bodied_constructors = true
+
+# Use expression body for methods (IDE0022)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0022
+# dotnet_diagnostic.IDE0022.severity = default
+csharp_style_expression_bodied_methods = true
+
+# Use expression body for operators (IDE0023 and IDE0024)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0023-ide0024
+# dotnet_diagnostic.IDE0023.severity = default
+# dotnet_diagnostic.IDE0024.severity = default
+csharp_style_expression_bodied_operators = true
+
+# Use expression body for properties (IDE0025)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0025
+# dotnet_diagnostic.IDE0025.severity = default
+csharp_style_expression_bodied_properties = true
+
+# Use expression body for indexers (IDE0026)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0026
+# dotnet_diagnostic.IDE0026.severity = default
+csharp_style_expression_bodied_indexers = true
+
+# Use expression body for accessors (IDE0027)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0027
+# dotnet_diagnostic.IDE0027.severity = default
+csharp_style_expression_bodied_accessors = true
+
+# Use expression body for lambdas (IDE0053)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0053
+# dotnet_diagnostic.IDE0053.severity = default
+csharp_style_expression_bodied_lambdas = true
+
+# Use expression body for local functions (IDE0061)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0061
+# dotnet_diagnostic.IDE0061.severity = default
+csharp_style_expression_bodied_local_functions = true
+
+##########################################
 # Expression-level preferences
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#expression-level-preferences
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
+
+# Simplify name (IDE0001)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0001
+# dotnet_diagnostic.IDE0001.severity = default
+
+# Simplify member access (IDE0002)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0002
+# dotnet_diagnostic.IDE0002.severity = default
+
+# Remove unnecessary cast (IDE0004)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0004
+# dotnet_diagnostic.IDE0004.severity = default
+
+# Add missing cases to switch statement (IDE0010)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0010
+# dotnet_diagnostic.IDE0010.severity = default
+
+# Use object initializers (IDE0017)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0017
+# dotnet_diagnostic.IDE0017.severity = default
 dotnet_style_object_initializer = true
+
+# Use collection initializers or expressions (IDE0028)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0028
+# dotnet_diagnostic.IDE0028.severity = default
 dotnet_style_collection_initializer = true
+
+# Null check can be simplified (IDE0029, IDE0030, and IDE0270)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0029-ide0030-ide0270
+# dotnet_diagnostic.IDE0029.severity = default
+# dotnet_diagnostic.IDE0030.severity = default
+# dotnet_diagnostic.IDE0270.severity = default
 dotnet_style_coalesce_expression = true
+
+# Use null propagation (IDE0031)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0031
+# dotnet_diagnostic.IDE0031.severity = default
 dotnet_style_null_propagation = true
+
+# Use auto-implemented property (IDE0032)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0032
+# dotnet_diagnostic.IDE0032.severity = default
 dotnet_style_prefer_auto_properties = true
+
+# Use explicitly provided tuple name (IDE0033)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0033
+# dotnet_diagnostic.IDE0033.severity = default
 dotnet_style_explicit_tuple_names = true
+
+# Remove unreachable code (IDE0035)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0035
+# dotnet_diagnostic.IDE0035.severity = default
+
+# Use inferred member names (IDE0037)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0037
+# dotnet_diagnostic.IDE0037.severity = default
 dotnet_style_prefer_inferred_tuple_names = true
 dotnet_style_prefer_inferred_anonymous_type_member_names = true
+
+# Use 'is null' check (IDE0041)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0041
+# dotnet_diagnostic.IDE0041.severity = default
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+
+# Use conditional expression for assignment (IDE0045)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0045
+# dotnet_diagnostic.IDE0045.severity = default
 dotnet_style_prefer_conditional_expression_over_assignment = true
-dotnet_diagnostic.IDE0045.severity = suggestion
+
+# Use conditional expression for return (IDE0046)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0046
+# dotnet_diagnostic.IDE0045.severity = default
 dotnet_style_prefer_conditional_expression_over_return = false
-dotnet_diagnostic.IDE0046.severity = suggestion
+
+# Convert anonymous type to tuple (IDE0050)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0050
+# dotnet_diagnostic.IDE0050.severity = default
+
+# Remove unused private member (IDE0051)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0051
+# dotnet_diagnostic.IDE0051.severity = default
+
+# Remove unread private member (IDE0052)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0052
+# dotnet_diagnostic.IDE0052.severity = default
+
+# Use compound assignment (IDE0054 and IDE0074)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0054-ide0074
+# dotnet_diagnostic.IDE0054.severity = default
+# dotnet_diagnostic.IDE0074.severity = default
 dotnet_style_prefer_compound_assignment = true
+
+# Remove unnecessary expression value (IDE0058)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0058
+# dotnet_diagnostic.IDE0058.severity = default
+csharp_style_unused_value_expression_statement_preference = discard_variable
+visual_basic_style_unused_value_expression_statement_preference = unused_local_variable
+
+# Remove unnecessary value assignment (IDE0059)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0059
+# dotnet_diagnostic.IDE0059.severity = default
+csharp_style_unused_value_assignment_preference = discard_variable
+visual_basic_style_unused_value_assignment_preference = unused_local_variable
+
+# Use 'System.HashCode.Combine' (IDE0070)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0070
+# dotnet_diagnostic.IDE0070.severity = default
+
+# Simplify interpolation (IDE0071)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0071
+# dotnet_diagnostic.IDE0071.severity = default
 dotnet_style_prefer_simplified_interpolation = true
+
+# Simplify conditional expression (IDE0075)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0075
+# dotnet_diagnostic.IDE0075.severity = default
 dotnet_style_prefer_simplified_boolean_expressions = true
+
+# Convert typeof to nameof (IDE0082)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0082
+# dotnet_diagnostic.IDE0082.severity = default
+
+# Remove unnecessary equality operator (IDE0100)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0100
+# dotnet_diagnostic.IDE0100.severity = default
+
+# Simplify LINQ expression (IDE0120)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0120
+# dotnet_diagnostic.IDE0120.severity = default
+
+# Namespace does not match folder structure (IDE0130)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0130
+# dotnet_diagnostic.IDE0130.severity = default
 dotnet_style_namespace_match_folder = true
-dotnet_diagnostic.IDE0130.severity = suggestion
+
+##########################################
+# Expression-level preferences
+# C# style rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#expression-level-preferences
+##########################################
+[*.{cs,csx,cake}]
+
+# Use throw expression (IDE0016)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0016
+# dotnet_diagnostic.IDE0016.severity = default
+csharp_style_throw_expression = true
+
+# Inline variable declaration (IDE0018)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0018
+# dotnet_diagnostic.IDE0018.severity = default
+csharp_style_inlined_variable_declaration = true
+
+# Simplify 'default' expression (IDE0034)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0034
+# dotnet_diagnostic.IDE0034.severity = default
+csharp_prefer_simple_default_expression = true
+
+# Use local function instead of lambda (IDE0039)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0039
+# dotnet_diagnostic.IDE0039.severity = default
+csharp_style_prefer_local_over_anonymous_function = true
+
+# Deconstruct variable declaration (IDE0042)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0042
+# dotnet_diagnostic.IDE0042.severity = default
+csharp_style_deconstructed_variable_declaration = true
+
+# Use index operator (IDE0056)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0056
+# dotnet_diagnostic.IDE0056.severity = default
+csharp_style_prefer_index_operator = true
+
+# Use range operator (IDE0057)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0057
+# dotnet_diagnostic.IDE0057.severity = default
+csharp_style_prefer_range_operator = true
+
+# Add missing cases to switch expression (IDE0072)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0072
+# dotnet_diagnostic.IDE0072.severity = default
+
+# Remove unnecessary suppression operator (IDE0080)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0080
+# dotnet_diagnostic.IDE0080.severity = default
+
+# Simplify new expression (IDE0090)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0090
+# dotnet_diagnostic.IDE0090.severity = default
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+
+# Remove unnecessary discard (IDE0110)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0110
+# dotnet_diagnostic.IDE0110.severity = default
+
+# Prefer 'null' check over type check (IDE0150)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0150
+# dotnet_diagnostic.IDE0150.severity = default
+csharp_style_prefer_null_check_over_type_check = true
+
+# Use tuple to swap values (IDE0180)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0180
+# dotnet_diagnostic.IDE0180.severity = default
+csharp_style_prefer_tuple_swap = true
+
+# Add explicit cast in foreach loop (IDE0220)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0220
+# dotnet_diagnostic.IDE0220.severity = default
 dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
 
+# Use UTF-8 string literal (IDE0230)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0230
+# dotnet_diagnostic.IDE0230.severity = default
+csharp_style_prefer_utf8_string_literals = true
+
+# Nullable directive is redundant (IDE0240)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0240
+# dotnet_diagnostic.IDE0240.severity = default
+
+# Nullable directive is unnecessary (IDE0241)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0241
+# dotnet_diagnostic.IDE0241.severity = default
+
+# Use collection expression for array (IDE0300)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0300
+# dotnet_diagnostic.IDE0300.severity = default
+# Use collection expression for empty (IDE0301)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0301
+# dotnet_diagnostic.IDE0301.severity = default
+# Use collection expression for stackalloc (IDE0302)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0302
+# dotnet_diagnostic.IDE0302.severity = default
+# Use collection expression for Create() (IDE0303)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0303
+# dotnet_diagnostic.IDE0303.severity = default
+# Use collection expression for builder (IDE0304)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0304
+# dotnet_diagnostic.IDE0304.severity = default
+# Use collection expression for fluent (IDE0305)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0305
+# dotnet_diagnostic.IDE0305.severity = default
+dotnet_style_prefer_collection_expression = when_types_exactly_match
+
+##########################################
+# Expression-level preferences
+# C# style rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#expression-level-preferences
+##########################################
+[*.{vb,vbx}]
+
+# Remove ByVal (IDE0081)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0081
+# dotnet_diagnostic.IDE0081.severity = default
+
+# Use pattern matching (IsNot operator) (IDE0084)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0084
+# dotnet_diagnostic.IDE0084.severity = default
+visual_basic_style_prefer_isnot_expression = true
+
+# Simplify object creation (IDE0140)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0140
+# dotnet_diagnostic.IDE0140.severity = default
+visual_basic_style_prefer_simplified_object_creation = true
+
+##########################################
 # Field preferences
-dotnet_style_readonly_field = true # NEW
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#field-preferences
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
 
+# Add readonly modifier (IDE0044)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0044
+# dotnet_diagnostic.IDE0044.severity = default
+dotnet_style_readonly_field = true
+
+##########################################
 # Language keyword vs. framework types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true # NEW
-dotnet_style_predefined_type_for_member_access = true # NEW
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#language-keyword-vs-framework-types-preferences
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
 
+# Use language keywords instead of framework type names for type references (IDE0049)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0049
+# dotnet_diagnostic.IDE0049.severity = default
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+##########################################
 # Modifier preferences
-dotnet_style_require_accessibility_modifiers = always # NEW
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#modifier-preferences
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
 
+# Order modifiers (IDE0036)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0036
+# dotnet_diagnostic.IDE0036.severity = default
+csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, required, volatile, async
+visual_basic_preferred_modifier_order = Partial, Default, Private, Protected, Public, Friend, NotOverridable, Overridable, MustOverride, Overloads, Overrides, MustInherit, NotInheritable, Static, Shared, Shadows, ReadOnly, WriteOnly, Dim, Const, WithEvents, Widening, Narrowing, Custom, Async
+
+# Add accessibility modifiers (IDE0040)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0040
+# dotnet_diagnostic.IDE0040.severity = default
+dotnet_style_require_accessibility_modifiers = always
+
+##########################################
+# Modifier preferences
+# C# style rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#modifier-preferences
+##########################################
+[*.{cs,csx,cake}]
+
+# Make local function static (IDE0062)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0062
+# dotnet_diagnostic.IDE0062.severity = default
+csharp_prefer_static_local_function = true
+
+# Make struct fields writable (IDE0064)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0064
+# dotnet_diagnostic.IDE0064.severity = default
+
+# Struct can be made 'readonly' (IDE0250)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0250
+# dotnet_diagnostic.IDE0250.severity = default
+csharp_style_prefer_readonly_struct = true
+
+# Member can be made 'readonly' (IDE0251)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0251
+# dotnet_diagnostic.IDE0251.severity = default
+csharp_style_prefer_readonly_struct_member = true
+
+# Make anonymous function static (IDE0320)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0320
+# dotnet_diagnostic.IDE0320.severity = default
+csharp_prefer_static_anonymous_function = true
+
+##########################################
+# New-line preferences
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#new-line-preferences
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
+
+# Allow multiple blank lines (IDE2000)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide2000
+dotnet_diagnostic.IDE2000.severity = none
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Allow embedded statements on same line (IDE2001)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide2001
+dotnet_diagnostic.IDE2001.severity = none
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+
+# Allow blank lines between consecutive braces (IDE2002)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide2002
+dotnet_diagnostic.IDE2002.severity = none
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+
+# Allow statement immediately after block (IDE2003)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide2003
+dotnet_diagnostic.IDE2003.severity = none
+dotnet_style_allow_statement_immediately_after_block_experimental = false
+
+# Allow blank line after colon in constructor initializer (IDE2004)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide2004
+dotnet_diagnostic.IDE2004.severity = none
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+
+# Allow blank line after token in conditional expression (IDE2005)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide2005
+dotnet_diagnostic.IDE2005.severity = none
+
+# Allow blank line after token in arrow expression (IDE2006)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide2006
+dotnet_diagnostic.IDE2006.severity = none
+
+##########################################
+# Null-checking preferences
+# C# style rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#null-checking-preferences
+##########################################
+[*.{cs,csx,cake}]
+
+# Use conditional delegate call (IDE1005)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide1005
+# dotnet_diagnostic.IDE1005.severity = default
+csharp_style_conditional_delegate_call = true
+
+##########################################
 # Parameter preferences
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#parameter-preferences
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
+
+# Remove unused parameter (IDE0060)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0060
+# dotnet_diagnostic.IDE0060.severity = default
 dotnet_code_quality_unused_parameters = all
 
+# Use 'nameof' (IDE0280)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0280
+# dotnet_diagnostic.IDE0280.severity = default
+
+##########################################
 # Parentheses preferences
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#parentheses-preferences
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
+
+# Parentheses preferences (IDE0047 and IDE0048)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0047-ide0048
+# dotnet_diagnostic.IDE0047.severity = default
+# dotnet_diagnostic.IDE0048.severity = default
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary
 
+##########################################
+# Pattern-matching preferences
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#pattern-matching-preferences
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
+
+# Use pattern matching to avoid 'as' followed by a 'null' check (IDE0019)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0019
+# dotnet_diagnostic.IDE0019.severity = default
+csharp_style_pattern_matching_over_as_with_null_check = true
+
+# Use pattern matching to avoid 'is' check followed by a cast (IDE0020 and IDE0038)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0020-ide0038
+# dotnet_diagnostic.IDE0020.severity = default
+# dotnet_diagnostic.IDE0038.severity = default
+csharp_style_pattern_matching_over_is_with_cast_check = true
+
+# Use switch expression (IDE0066)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0066
+# dotnet_diagnostic.IDE0066.severity = default
+csharp_style_prefer_switch_expression = true
+
+# Use pattern matching (IDE0078 and IDE0260)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0078-ide0260
+# dotnet_diagnostic.IDE0078.severity = default
+# dotnet_diagnostic.IDE0260.severity = default
+csharp_style_prefer_pattern_matching = true
+
+# Use pattern matching (not operator) (IDE0083)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0083
+# dotnet_diagnostic.IDE0083.severity = default
+csharp_style_prefer_not_pattern = true
+
+# Simplify property pattern (IDE0170)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0170
+# dotnet_diagnostic.IDE0170.severity = default
+csharp_style_prefer_extended_property_pattern = true
+
+##########################################
 # Suppression preferences
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#suppression-preferences
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
+
+# Remove unnecessary suppression (IDE0079)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0079
+# dotnet_diagnostic.IDE0079.severity = default
 dotnet_remove_unnecessary_suppression_exclusions = none
 
-# "this."" preferences
+##########################################
+# This. and me. preferences
+# .NET style rules (C# and Visual Basic)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#this-and-me-preferences
+##########################################
+[*.{cs,csx,cake,vb,vbx}]
+
+# this and Me preferences (IDE0003 and IDE0009)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
+# dotnet_diagnostic.IDE0003.severity = default
+# dotnet_diagnostic.IDE0009.severity = default
 dotnet_style_qualification_for_field = false
 dotnet_style_qualification_for_property = false
 dotnet_style_qualification_for_method = false
 dotnet_style_qualification_for_event = false
 
 ##########################################
-# Language Rules - C#
-# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
+# var preferences
+# C# style rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules#this-and-me-preferences
 ##########################################
+[*.{cs,csx,cake,vb,vbx}]
 
-[*.{cs,csx,cake}]
-
-# 'using' directive preferences
-csharp_using_directive_placement = outside_namespace
-
-# Code-block preferences
-csharp_prefer_braces = true
-csharp_prefer_simple_using_statement = true
-dotnet_diagnostic.IDE0063.severity = suggestion
-csharp_style_namespace_declarations = file_scoped
-csharp_style_prefer_method_group_conversion = true # NEW
-csharp_style_prefer_top_level_statements = true # NEW
-
-# Expression-bodied members
-csharp_style_expression_bodied_constructors = true
-csharp_style_expression_bodied_methods = true
-csharp_style_expression_bodied_operators = true
-csharp_style_expression_bodied_properties = true
-csharp_style_expression_bodied_indexers = true
-csharp_style_expression_bodied_accessors = true
-csharp_style_expression_bodied_lambdas = true
-csharp_style_expression_bodied_local_functions = true
-
-# Expression-level preferences
-csharp_style_unused_value_expression_statement_preference = discard_variable
-dotnet_diagnostic.IDE0058.severity = suggestion
-csharp_style_unused_value_assignment_preference = discard_variable
-dotnet_diagnostic.IDE0059.severity = suggestion
-csharp_style_throw_expression = true
-csharp_style_inlined_variable_declaration = true
-csharp_prefer_simple_default_expression = true
-csharp_style_prefer_local_over_anonymous_function = true # New
-csharp_style_deconstructed_variable_declaration = true
-csharp_style_prefer_index_operator = true
-csharp_style_prefer_range_operator = true
-csharp_style_implicit_object_creation_when_type_is_apparent = true
-csharp_style_prefer_null_check_over_type_check = true
-csharp_style_prefer_tuple_swap = true # NEW
-csharp_style_prefer_utf8_string_literals = true # NEW
-
-# Modifier preferences
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
-csharp_prefer_static_local_function = true
-csharp_style_prefer_readonly_struct = true # NEW
-csharp_style_prefer_readonly_struct_member = true # NEW
-
-# "null" checking preferences
-csharp_style_conditional_delegate_call = true
-
-# Pattern-matching preferences
-csharp_style_pattern_matching_over_as_with_null_check = true
-csharp_style_pattern_matching_over_is_with_cast_check = true
-csharp_style_prefer_switch_expression = true
-csharp_style_prefer_pattern_matching = true
-csharp_style_prefer_not_pattern = true
-csharp_style_prefer_extended_property_pattern = true # NEW
-
-# 'var' preferences
+# 'var' preferences (IDE0007 and IDE0008)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0007-ide0008
+# dotnet_diagnostic.IDE0007.severity = default
+# dotnet_diagnostic.IDE0008.severity = default
 csharp_style_var_for_built_in_types = true
 csharp_style_var_when_type_is_apparent = true
 csharp_style_var_elsewhere = true
 
-# Undocumented
-# https://github.com/dotnet/docs/issues/28791
-csharp_style_prefer_primary_constructors = true # NEW
-
 ##########################################
-# .NET Coding Conventions - .NET
-# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/dotnet-formatting-options
+# Formatting rules
+# .NET formatting options
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/dotnet-formatting-options
 ##########################################
-
 [*.{cs,csx,cake,vb,vbx}]
 
-# .NET code refactoring options
-# https://learn.microsoft.com/visualstudio/ide/reference/code-styles-refactoring-options
-dotnet_style_operator_placement_when_wrapping = end_of_line
-
-##########################################
-# Formatting Rules - .NET
-# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/dotnet-formatting-options
-##########################################
-
-[*.{cs,csx,cake,vb,vbx}]
+# Formatting rule (IDE0055)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0055
+# dotnet_diagnostic.IDE0055.severity = default
 
 # Using directive options
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/dotnet-formatting-options#using-directive-options
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
 
 ##########################################
-# Formatting Rules - C#
-# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options
+# Formatting rules
+# C# Formatting options
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options
 ##########################################
-
 [*.{cs,csx,cake}]
 
-# Newline options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#new-line-options
+# New-line options
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#new-line-options
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -256,7 +750,7 @@ csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
 # Indentation options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#indentation-options
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#indentation-options
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_indent_labels = no_change
@@ -265,7 +759,7 @@ csharp_indent_braces = false
 csharp_indent_case_contents_when_block = false
 
 # Spacing options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#spacing-options
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#spacing-options
 csharp_space_after_cast = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_between_parentheses = false
@@ -290,16 +784,20 @@ csharp_space_between_empty_square_brackets = false
 csharp_space_between_square_brackets = false
 
 # Wrap options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#wrap-options
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#wrap-options
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = false
 
 ##########################################
-# .NET Naming Rules
-# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/naming-rules
+# Naming rules
+# .NET naming rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/naming-rules
 ##########################################
-
 [*.{cs,csx,cake,vb,vbx}]
+
+# Naming rule violation (IDE1006)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/naming-rules#rule-id-ide1006-naming-rule-violation
+# dotnet_diagnostic.IDE1006.severity = default
 
 ##########################################
 # Styles
@@ -317,6 +815,10 @@ dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
 # prefix_type_parameters_with_t_style - Generic Type Parameters must be PascalCase and the first character must be a 'T'
 dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
 dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
+# async methods should end with 'Async'
+dotnet_naming_style.async_suffix_style.required_suffix = Async
+dotnet_naming_style.async_suffix_style.word_separator =
+dotnet_naming_style.async_suffix_style.capitalization = pascal_case
 # disallowed_style - Anything that has this style applied is marked as disallowed
 dotnet_naming_style.disallowed_style.capitalization  = pascal_case
 dotnet_naming_style.disallowed_style.required_prefix = ____RULE_VIOLATION____
@@ -416,6 +918,16 @@ dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols  = sanity_chec
 dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style    = internal_error_style
 dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
 
+##########################################
+# Naming rules for fields follow the StyleCop analyzers
+##########################################
+
+dotnet_naming_symbols.async_methods_group.applicable_accessibilities = *
+dotnet_naming_symbols.async_methods_group.applicable_kinds = method
+dotnet_naming_symbols.async_methods_group.required_modifiers = async
+dotnet_naming_rule.async_methods_must_have_async_suffix_rule.symbols = async_methods_group
+dotnet_naming_rule.async_methods_must_have_async_suffix_rule.style = async_suffix_style
+dotnet_naming_rule.async_methods_must_have_async_suffix_rule.severity = error
 
 ##########################################
 # Other Naming Rules
@@ -459,443 +971,3308 @@ dotnet_naming_rule.parameters_rule.style                = camel_case_style
 dotnet_naming_rule.parameters_rule.severity             = warning
 
 ##########################################
-# License
+# Miscellaneous rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/miscellaneous-rules
 ##########################################
-# The following applies as to the .editorconfig file ONLY, and is
-# included below for reference, per the requirements of the license
-# corresponding to this .editorconfig file.
-# See: https://github.com/RehanSaeed/EditorConfig
-#
-# MIT License
-#
-# Copyright (c) 2017-2019 Muhammad Rehan Saeed
-# Copyright (c) 2019 Henry Gabryjelski
-#
-# Permission is hereby granted, free of charge, to any
-# person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the
-# Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute,
-# sublicense, and/or sell copies of the Software, and to permit
-# persons to whom the Software is furnished to do so, subject
-# to the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-##########################################
+[*.{cs,csx,cake,vb,vbx}]
 
+# Remove invalid global 'SuppressMessageAttribute' (IDE0076)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0076
+# dotnet_diagnostic.IDE0076.severity = default
+
+# Avoid legacy format target in global 'SuppressMessageAttribute' (IDE0077)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0077
+# dotnet_diagnostic.IDE0077.severity = default
 
 ##########################################
-# StyleCop rules
+# .NET Coding Conventions - .NET
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/dotnet-formatting-options
 ##########################################
-[*]
-# SA1101: Prefix local calls with this
+[*.{cs,csx,cake,vb,vbx}]
+
+# .NET code refactoring options
+# https://learn.microsoft.com/visualstudio/ide/reference/code-styles-refactoring-options
+dotnet_style_operator_placement_when_wrapping = end_of_line
+
+##########################################
+# Code Quality rules
+# Design rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/design-warnings
+##########################################
+[*.{cs,csx,cake}]
+
+# CA1000: Do not declare static members on generic types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000
+# dotnet_diagnostic.CA1000.severity = default
+# dotnet_code_quality.CA1000.api_surface = all
+
+# CA1001: Types that own disposable fields should be disposable
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+# dotnet_diagnostic.CA1001.severity = default
+# dotnet_code_quality.CA1001.api_surface = all
+
+# CA1002: Do not expose generic lists
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1002
+# dotnet_diagnostic.CA1002.severity = default
+# dotnet_code_quality.CA1002.api_surface = all
+
+# CA1003: Use generic event handler instances
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1003
+# dotnet_diagnostic.CA1003.severity = default
+# dotnet_code_quality.CA1003.api_surface = all
+
+# CA1005: Avoid excessive parameters on generic types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1005
+# dotnet_diagnostic.CA1005.severity = default
+# dotnet_code_quality.CA1005.api_surface = all
+
+# CA1008: Enums should have zero value
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1008
+# dotnet_diagnostic.CA1008.severity = default
+# dotnet_code_quality.CA1008.api_surface = all
+
+# CA1010: Collections should implement generic interface
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1010
+# dotnet_diagnostic.CA1010.severity = default
+# dotnet_code_quality.CA1010.api_surface = all
+
+# CA1012: Abstract types should not have public constructors
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1012
+# dotnet_diagnostic.CA1012.severity = default
+# dotnet_code_quality.CA1012.api_surface = all
+
+# CA1014: Mark assemblies with CLSCompliantAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+# dotnet_diagnostic.CA1014.severity = default
+# dotnet_code_quality.CA1014.api_surface = all
+
+# CA1016: Mark assemblies with AssemblyVersionAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1016
+# dotnet_diagnostic.CA1016.severity = default
+# dotnet_code_quality.CA1016.api_surface = all
+
+# CA1017: Mark assemblies with ComVisibleAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1017
+# dotnet_diagnostic.CA1017.severity = default
+# dotnet_code_quality.CA1017.api_surface = all
+
+# CA1018: Mark attributes with AttributeUsageAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1018
+# dotnet_diagnostic.CA1018.severity = default
+# dotnet_code_quality.CA1018.api_surface = all
+
+# CA1019: Define accessors for attribute arguments
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1019
+# dotnet_diagnostic.CA1019.severity = default
+# dotnet_code_quality.CA1019.api_surface = all
+
+# CA1021: Avoid out parameters
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1021
+# dotnet_diagnostic.CA1021.severity = default
+# dotnet_code_quality.CA1021.api_surface = all
+
+# CA1024: Use properties where appropriate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1024
+# dotnet_diagnostic.CA1024.severity = default
+# dotnet_code_quality.CA1024.api_surface = all
+
+# CA1027: Mark enums with FlagsAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1027
+# dotnet_diagnostic.CA1027.severity = default
+# dotnet_code_quality.CA1027.api_surface = all
+
+# CA1028: Enum storage should be Int32
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1028
+# dotnet_diagnostic.CA1028.severity = default
+# dotnet_code_quality.CA1028.api_surface = all
+
+# CA1030: Use events where appropriate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1030
+# dotnet_diagnostic.CA1030.severity = default
+# dotnet_code_quality.CA1030.api_surface = all
+
+# CA1031: Do not catch general exception types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+# dotnet_diagnostic.CA1031.severity = default
+# dotnet_code_quality.CA1031.api_surface = all
+
+# CA1032: Implement standard exception constructors
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1032
+# dotnet_diagnostic.CA1032.severity = default
+# dotnet_code_quality.CA1032.api_surface = all
+
+# CA1033: Interface methods should be callable by child types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1033
+# dotnet_diagnostic.CA1033.severity = default
+# dotnet_code_quality.CA1033.api_surface = all
+
+# CA1034: Nested types should not be visible
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1034
+# dotnet_diagnostic.CA1034.severity = default
+# dotnet_code_quality.CA1034.api_surface = all
+
+# CA1036: Override methods on comparable types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1036
+# dotnet_diagnostic.CA1036.severity = default
+# dotnet_code_quality.CA1036.api_surface = all
+
+# CA1040: Avoid empty interfaces
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1040
+# dotnet_diagnostic.CA1040.severity = default
+# dotnet_code_quality.CA1040.api_surface = all
+
+# CA1041: Provide ObsoleteAttribute message
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1041
+# dotnet_diagnostic.CA1041.severity = default
+# dotnet_code_quality.CA1041.api_surface = all
+
+# CA1043: Use integral or string argument for indexers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1043
+# dotnet_diagnostic.CA1043.severity = default
+# dotnet_code_quality.CA1043.api_surface = all
+
+# CA1044: Properties should not be write only
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1044
+# dotnet_diagnostic.CA1044.severity = default
+# dotnet_code_quality.CA1044.api_surface = all
+
+# CA1045: Do not pass types by reference
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1045
+# dotnet_diagnostic.CA1045.severity = default
+# dotnet_code_quality.CA1045.api_surface = all
+
+# CA1046: Do not overload operator equals on reference types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1046
+# dotnet_diagnostic.CA1046.severity = default
+# dotnet_code_quality.CA1046.api_surface = all
+
+# CA1047: Do not declare protected members in sealed types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1047
+# dotnet_diagnostic.CA1047.severity = default
+# dotnet_code_quality.CA1047.api_surface = all
+
+# CA1050: Declare types in namespaces
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1050
+# dotnet_diagnostic.CA1050.severity = default
+# dotnet_code_quality.CA1050.api_surface = all
+
+# CA1051: Do not declare visible instance fields
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
+# dotnet_diagnostic.CA1051.severity = default
+# dotnet_code_quality.CA1051.api_surface = all
+
+# CA1052: Static holder types should be Static or NotInheritable
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052
+# dotnet_diagnostic.CA1052.severity = default
+# dotnet_code_quality.CA1052.api_surface = all
+
+# CA1053: Static holder types should not have default constructors
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1053
+# dotnet_diagnostic.CA1053.severity = default
+# dotnet_code_quality.CA1053.api_surface = all
+
+# CA1054: URI parameters should not be strings
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1054
+# dotnet_diagnostic.CA1054.severity = default
+# dotnet_code_quality.CA1054.api_surface = all
+
+# CA1055: URI return values should not be strings
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1055
+# dotnet_diagnostic.CA1055.severity = default
+# dotnet_code_quality.CA1055.api_surface = all
+
+# CA1056: URI properties should not be strings
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1056
+# dotnet_diagnostic.CA1056.severity = default
+# dotnet_code_quality.CA1056.api_surface = all
+
+# CA1058: Types should not extend certain base types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1058
+# dotnet_diagnostic.CA1058.severity = default
+# dotnet_code_quality.CA1058.api_surface = all
+
+# CA1060: Move P/Invokes to NativeMethods class
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1060
+# dotnet_diagnostic.CA1060.severity = default
+# dotnet_code_quality.CA1060.api_surface = all
+
+# CA1061: Do not hide base class methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+# dotnet_diagnostic.CA1061.severity = default
+# dotnet_code_quality.CA1061.api_surface = all
+
+# CA1062: Validate arguments of public methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+# dotnet_diagnostic.CA1062.severity = default
+# dotnet_code_quality.CA1062.api_surface = all
+
+# CA1063: Implement IDisposable correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
+# dotnet_diagnostic.CA1063.severity = default
+# dotnet_code_quality.CA1063.api_surface = all
+
+# CA1064: Exceptions should be public
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1064
+# dotnet_diagnostic.CA1064.severity = default
+# dotnet_code_quality.CA1064.api_surface = all
+
+# CA1065: Do not raise exceptions in unexpected locations
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1065
+# dotnet_diagnostic.CA1065.severity = default
+# dotnet_code_quality.CA1065.api_surface = all
+
+# CA1066: Implement IEquatable when overriding Equals
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
+# dotnet_diagnostic.CA1066.severity = default
+# dotnet_code_quality.CA1066.api_surface = all
+
+# CA1067: Override Equals when implementing IEquatable
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067
+# dotnet_diagnostic.CA1067.severity = default
+# dotnet_code_quality.CA1067.api_surface = all
+
+# CA1068: CancellationToken parameters must come last
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1068
+# dotnet_diagnostic.CA1068.severity = default
+# dotnet_code_quality.CA1068.api_surface = all
+
+# CA1069: Enums should not have duplicate values
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1069
+# dotnet_diagnostic.CA1069.severity = default
+# dotnet_code_quality.CA1069.api_surface = all
+
+# CA1070: Do not declare event fields as virtual
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1070
+# dotnet_diagnostic.CA1070.severity = default
+# dotnet_code_quality.CA1070.api_surface = all
+
+##########################################
+# Code Quality rules
+# Documentation rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/documentation-warnings
+##########################################
+[*.{cs,csx,cake}]
+
+# CA1200: Avoid using cref tags with a prefix
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1200
+# dotnet_diagnostic.CA1200.severity = default
+
+##########################################
+# Code Quality rules
+# Globalization rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/globalization-warnings
+##########################################
+[*.{cs,csx,cake}]
+
+# CA1303: Do not pass literals as localized parameters
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1303
+# dotnet_diagnostic.CA1303.severity = default
+# dotnet_code_quality.CA1303.excluded_symbol_names =
+# dotnet_code_quality.CA1303.excluded_type_names_with_derived_types =
+# dotnet_code_quality.CA1303.use_naming_heuristic = true
+
+# CA1304: Specify CultureInfo
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1304
+# dotnet_diagnostic.CA1304.severity = default
+# dotnet_code_quality.CA1304.excluded_symbol_names =
+# dotnet_code_quality.CA1304.excluded_type_names_with_derived_types =
+
+# CA1305: Specify IFormatProvider
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
+# dotnet_diagnostic.CA1305.severity = default
+# dotnet_code_quality.CA1305.excluded_symbol_names =
+# dotnet_code_quality.CA1305.excluded_type_names_with_derived_types =
+
+# CA1307: Specify StringComparison for clarity
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1307
+# dotnet_diagnostic.CA1307.severity = default
+
+# CA1308: Normalize strings to uppercase
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+# dotnet_diagnostic.CA1308.severity = default
+
+# CA1309: Use ordinal StringComparison
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1309
+# dotnet_diagnostic.CA1309.severity = default
+
+# CA1310: Specify StringComparison for correctness
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1310
+# dotnet_diagnostic.CA1310.severity = default
+
+# CA1311: Specify a culture or use an invariant version
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311
+# dotnet_diagnostic.CA1311.severity = default
+
+# CA2101: Specify marshalling for P/Invoke string arguments
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2101
+# dotnet_diagnostic.CA2101.severity = default
+
+##########################################
+# Code Quality rules
+# Portability and interoperability rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/interoperability-warnings
+##########################################
+[*.{cs,csx,cake}]
+
+# CA1401: P/Invokes should not be visible
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1401
+# dotnet_diagnostic.CA1401.severity = default
+
+# CA1416: Validate platform compatibility
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+# dotnet_diagnostic.CA1416.severity = default
+
+# CA1417: Do not use OutAttribute on string parameters for P/Invokes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1417
+# dotnet_diagnostic.CA1417.severity = default
+
+# CA1418: Validate platform compatibility
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1418
+# dotnet_diagnostic.CA1418.severity = default
+
+# CA1419: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1419
+# dotnet_diagnostic.CA1419.severity = default
+
+# CA1420: Property, type, or attribute requires runtime marshalling
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1420
+# dotnet_diagnostic.CA1420.severity = default
+
+# CA1421: Method uses runtime marshalling when DisableRuntimeMarshallingAttribute is applied
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421
+# dotnet_diagnostic.CA1421.severity = default
+
+# CA1422: Validate platform compatibility - obsoleted APIs
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1422
+# dotnet_diagnostic.CA1422.severity = default
+
+##########################################
+# Code Quality rules
+# Maintainability rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/maintainability-warnings
+##########################################
+[*.{cs,csx,cake}]
+
+# CA1501: Avoid excessive inheritance
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1501
+# dotnet_diagnostic.CA1501.severity = default
+# dotnet_code_quality.CA1501.additional_inheritance_excluded_symbol_names =
+
+# CA1502: Avoid excessive complexity
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1502
+# dotnet_diagnostic.CA1502.severity = default
+
+# CA1505: Avoid unmaintainable code
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1505
+# dotnet_diagnostic.CA1505.severity = default
+
+# CA1506: Avoid excessive class coupling
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1506
+# dotnet_diagnostic.CA1506.severity = default
+
+# CA1507: Use nameof in place of string
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1507
+# dotnet_diagnostic.CA1507.severity = default
+
+# CA1508: Avoid dead conditional code
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1508
+# dotnet_diagnostic.CA1508.severity = default
+# dotnet_code_quality.CA1508.excluded_symbol_names
+
+# CA1509: Invalid entry in code metrics configuration file
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1509
+# dotnet_diagnostic.CA1509.severity = default
+
+# CA1510: Use ArgumentNullException throw helper
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510
+# dotnet_diagnostic.CA1510.severity = default
+
+# CA1511: Use ArgumentException throw helper
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511
+# dotnet_diagnostic.CA1511.severity = default
+
+# CA1512: Use ArgumentOutOfRangeException throw helper
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512
+# dotnet_diagnostic.CA1512.severity = default
+
+# CA1513: Use ObjectDisposedException throw helper
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513
+# dotnet_diagnostic.CA1513.severity = default
+
+# CA1514: Avoid redundant length argument
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1514
+# dotnet_diagnostic.CA1514.severity = default
+
+# CA1515: Consider making public types internal
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1515
+# dotnet_diagnostic.CA1515.severity = default
+
+##########################################
+# Code Quality rules
+# Naming rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/naming-warnings
+##########################################
+[*.{cs,csx,cake}]
+
+# CA1700: Do not name enum values 'Reserved'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1700
+# dotnet_diagnostic.CA1700.severity = default
+# dotnet_code_quality.CA1700.api_surface = all
+
+# CA1707: Identifiers should not contain underscores
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707
+# dotnet_diagnostic.CA1707.severity = default
+# dotnet_code_quality.CA1701.api_surface = all
+
+# CA1708: Identifiers should differ by more than case
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1708
+# dotnet_diagnostic.CA1708.severity = default
+# dotnet_code_quality.CA1708.api_surface = all
+
+# CA1710: Identifiers should have correct suffix
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1710
+# dotnet_diagnostic.CA1710.severity = default
+# dotnet_code_quality.CA1710.api_surface = all
+# dotnet_code_quality.CA1710.exclude_indirect_base_types = true
+# dotnet_code_quality.CA1710.additional_required_suffixes = [type]->[suffix]
+
+# CA1711: Identifiers should not have incorrect suffix
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1711
+# dotnet_diagnostic.CA1711.severity = default
+# dotnet_code_quality.CA1711.api_surface = all
+# dotnet_code_quality.ca1711.allowed_suffixes =
+
+# CA1712: Do not prefix enum values with type name
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1712
+# dotnet_diagnostic.CA1712.severity = default
+dotnet_code_quality.CA1712.enum_values_prefix_trigger = AnyEnumValue
+
+# CA1713: Events should not have before or after prefix
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1713
+# dotnet_diagnostic.CA1713.severity = default
+
+# CA1714: Flags enums should have plural names
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1714
+# dotnet_diagnostic.CA1714.severity = default
+# dotnet_code_quality.CA1714.api_surface = all
+
+# CA1715: Identifiers should have correct prefix
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1715
+# dotnet_diagnostic.CA1715.severity = default
+# dotnet_code_quality.CA1715.api_surface = all
+# dotnet_code_quality.CA1715.exclude_single_letter_type_parameters = true
+# dotnet_code_quality.CA2007.allow_single_letter_type_parameters = true
+
+# CA1716: Identifiers should not match keywords
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
+# dotnet_diagnostic.CA1716.severity = default
+# dotnet_code_quality.CA1716.api_surface = all
+# dotnet_code_quality.CA1716.analyzed_symbol_kinds = Namespace, NamedType, Method, Property, Event
+
+# CA1717: Only FlagsAttribute enums should have plural names
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1717
+# dotnet_diagnostic.CA1717.severity = default
+# dotnet_code_quality.CA1717.api_surface = all
+
+# CA1720: Identifiers should not contain type names
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
+# dotnet_diagnostic.CA1720.severity = default
+# dotnet_code_quality.CA1720.api_surface = all
+
+# CA1721: Property names should not match get methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1721
+# dotnet_diagnostic.CA1721.severity = default
+# dotnet_code_quality.CA1721.api_surface = all
+
+# CA1724: Type names should not match namespaces
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1724
+# dotnet_diagnostic.CA1724.severity = default
+
+# CA1725: Parameter names should match base declaration
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+# dotnet_diagnostic.CA1725.severity = default
+# dotnet_code_quality.CA1725.api_surface = all
+
+# CA1727: Use PascalCase for named placeholders
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1727
+# dotnet_diagnostic.CA1727.severity = default
+
+##########################################
+# Code Quality rules
+# Performance rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/performance-warnings
+##########################################
+[*.{cs,csx,cake}]
+
+# CA1802: Use Literals Where Appropriate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1802
+# dotnet_diagnostic.CA1802.severity = default
+# dotnet_code_quality.CA1802.api_surface = all
+# dotnet_code_quality.CA1802.required_modifiers = none
+
+# CA1805: Do not initialize unnecessarily
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1805
+# dotnet_diagnostic.CA1805.severity = default
+
+# CA1806: Do not ignore method results
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1806
+# dotnet_diagnostic.CA1806.severity = default
+# dotnet_code_quality.CA1806.additional_use_results_methods =
+
+# CA1810: Initialize reference type static fields inline
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1810
+# dotnet_diagnostic.CA1810.severity = default
+
+# CA1812: Avoid uninstantiated internal classes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+# dotnet_diagnostic.CA1812.severity = default
+# dotnet_code_quality.CA1812.ignore_internalsvisibleto = true
+
+# CA1813: Avoid unsealed attributes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1813
+# dotnet_diagnostic.CA1813.severity = default
+
+# CA1814: Prefer jagged arrays over multidimensional
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1814
+# dotnet_diagnostic.CA1814.severity = default
+
+# CA1815: Override equals and operator equals on value types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
+# dotnet_diagnostic.CA1815.severity = default
+# dotnet_code_quality.CA1815.api_surface = all
+
+# CA1819: Properties should not return arrays
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819
+# dotnet_diagnostic.CA1819.severity = default
+# dotnet_code_quality.CA1819.api_surface = all
+
+# CA1820: Test for empty strings using string length
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1820
+# dotnet_diagnostic.CA1820.severity = default
+
+# CA1821: Remove empty finalizers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1821
+# dotnet_diagnostic.CA1821.severity = default
+
+# CA1822: Mark members as static
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822
+# dotnet_diagnostic.CA1822.severity = default
+# dotnet_code_quality.CA1822.api_surface = all
+
+# CA1823: Avoid unused private fields
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1823
+# dotnet_diagnostic.CA1823.severity = default
+
+# CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1824
+# dotnet_diagnostic.CA1824.severity = default
+
+# CA1825: Avoid zero-length array allocations
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
+# dotnet_diagnostic.CA1825.severity = default
+
+# CA1826: Use property instead of Linq Enumerable method
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1826
+# dotnet_diagnostic.CA1826.severity = default
+
+# CA1827: Do not use Count()/LongCount() when Any() can be used
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1827
+# dotnet_diagnostic.CA1827.severity = default
+
+# CA1828: Do not use CountAsync/LongCountAsync when AnyAsync can be used
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1828
+# dotnet_diagnostic.CA1828.severity = default
+
+# CA1829: Use Length/Count property instead of Enumerable.Count method
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829
+# dotnet_diagnostic.CA1829.severity = default
+
+# CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1830
+# dotnet_diagnostic.CA1830.severity = default
+
+# CA1831: Use AsSpan instead of Range-based indexers for string when appropriate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1831
+# dotnet_diagnostic.CA1831.severity = default
+
+# CA1832: Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1832
+# dotnet_diagnostic.CA1832.severity = default
+
+# CA1833: Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1833
+# dotnet_diagnostic.CA1833.severity = default
+
+# CA1834: Use StringBuilder.Append(char) for single character strings
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1834
+# dotnet_diagnostic.CA1834.severity = default
+
+# CA1835: Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1835
+# dotnet_diagnostic.CA1835.severity = default
+
+# CA1836: Prefer IsEmpty over Count when available
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1836
+# dotnet_diagnostic.CA1836.severity = default
+
+# CA1837: Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1837
+# dotnet_diagnostic.CA1837.severity = default
+
+# CA1838: Avoid StringBuilder parameters for P/Invokes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1838
+# dotnet_diagnostic.CA1838.severity = default
+
+# CA1839: Use Environment.ProcessPath instead of Process.GetCurrentProcess().MainModule.FileName
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1839
+# dotnet_diagnostic.CA1839.severity = default
+
+# CA1840: Use Environment.CurrentManagedThreadId instead of Thread.CurrentThread.ManagedThreadId
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1840
+# dotnet_diagnostic.CA1840.severity = default
+
+# CA1841: Prefer Dictionary Contains methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1841
+# dotnet_diagnostic.CA1841.severity = default
+
+# CA1842: Do not use 'WhenAll' with a single task
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1842
+# dotnet_diagnostic.CA1842.severity = default
+
+# CA1843: Do not use 'WaitAll' with a single task
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843
+# dotnet_diagnostic.CA1843.severity = default
+
+# CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1844
+# dotnet_diagnostic.CA1844.severity = default
+
+# CA1845: Use span-based 'string.Concat'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1845
+# dotnet_diagnostic.CA1845.severity = default
+
+# CA1846: Prefer AsSpan over Substring
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1846
+# dotnet_diagnostic.CA1846.severity = default
+
+# CA1847: Use String.Contains(char) instead of String.Contains(string) with single characters
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1847
+# dotnet_diagnostic.CA1847.severity = default
+
+# CA1848: Use the LoggerMessage delegates
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848
+# dotnet_diagnostic.CA1848.severity = default
+
+# CA1849: Call async methods when in an async method
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849
+# dotnet_diagnostic.CA1849.severity = default
+
+# CA1850: Prefer static HashData method over ComputeHash
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1850
+# dotnet_diagnostic.CA1850.severity = default
+
+# CA1851: Possible multiple enumerations of IEnumerable collection
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851
+# dotnet_diagnostic.CA1851.severity = default
+
+# CA1852: Seal internal types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
+# dotnet_diagnostic.CA1852.severity = default
+
+# CA1853: Unnecessary call to 'Dictionary.ContainsKey(key)'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853
+# dotnet_diagnostic.CA1853.severity = default
+
+# CA1854: Prefer the IDictionary.TryGetValue(TKey, out TValue) method
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854
+# dotnet_diagnostic.CA1854.severity = default
+
+# CA1855: Use Span<T>.Clear() instead of Span<T>.Fill()
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855
+# dotnet_diagnostic.CA1855.severity = default
+
+# CA1856: Incorrect usage of ConstantExpected attribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856
+# dotnet_diagnostic.CA1856.severity = default
+
+# CA1857: The parameter expects a constant for optimal performance
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857
+# dotnet_diagnostic.CA1857.severity = default
+
+# CA1858: Use StartsWith instead of IndexOf
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858
+# dotnet_diagnostic.CA1858.severity = default
+
+# CA1859: Use concrete types when possible for improved performance
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
+# dotnet_diagnostic.CA1859.severity = default
+
+# CA1860: Avoid using 'Enumerable.Any()' extension method
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860
+# dotnet_diagnostic.CA1860.severity = default
+
+# CA1861: Avoid constant arrays as arguments
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
+# dotnet_diagnostic.CA1861.severity = default
+
+# CA1862: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862
+# dotnet_diagnostic.CA1862.severity = default
+
+# CA1863: Use 'CompositeFormat'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1863
+# dotnet_diagnostic.CA1863.severity = default
+
+# CA1864: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1864
+# dotnet_diagnostic.CA1864.severity = default
+
+# CA1865-CA1867: Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1865-ca1867
+# dotnet_diagnostic.CA1865.severity = default
+# dotnet_diagnostic.CA1866.severity = default
+# dotnet_diagnostic.CA1867.severity = default
+
+# CA1868: Unnecessary call to 'Contains' for sets
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1868
+# dotnet_diagnostic.CA1868.severity = default
+
+# CA1869: Cache and reuse 'JsonSerializerOptions' instances
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1869
+# dotnet_diagnostic.CA1869.severity = default
+
+# CA1870: Use a cached 'SearchValues' instance
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1870
+# dotnet_diagnostic.CA1870.severity = default
+
+# CA1871: Do not pass a nullable struct to 'ArgumentNullException.ThrowIfNull'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1871
+# dotnet_diagnostic.CA1871.severity = default
+
+# CA1872: Prefer 'Convert.ToHexString' and 'Convert.ToHexStringLower' over call chains based on 'BitConverter.ToString'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1872
+# dotnet_diagnostic.CA1872.severity = default
+
+##########################################
+# Code Quality rules
+# SingleFile rules
+# https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/overview
+##########################################
+[*.{cs,csx,cake}]
+
+# IL3000: Avoid accessing Assembly file path when publishing as a single file
+# https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000
+# dotnet_diagnostic.IL3000.severity = default
+
+# IL3001: Avoid accessing Assembly file path when publishing as a single file
+# https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3001
+# dotnet_diagnostic.IL3001.severity = default
+
+# IL3002: Avoid calling members annotated with 'RequiresAssemblyFilesAttribute' when publishing as a single file.
+# https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3002
+# dotnet_diagnostic.IL3002.severity = default
+
+# IL3003: 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides
+# https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3003
+# dotnet_diagnostic.IL3003.severity = default
+
+##########################################
+# Code Quality rules
+# Reliability rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/reliability-warnings
+##########################################
+[*.{cs,csx,cake}]
+
+# CA2000: Dispose objects before losing scope
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
+# dotnet_diagnostic.CA2000.severity = default
+# dotnet_code_quality.CA2000.excluded_symbol_names =
+# dotnet_code_quality.CA2000.excluded_type_names_with_derived_types =
+
+# CA2002: Do not lock on objects with weak identity
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2002
+# dotnet_diagnostic.CA2002.severity = default
+
+# CA2007: Do not directly await a Task
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2007
+# dotnet_diagnostic.CA2007.severity = default
+# dotnet_code_quality.CA2007.exclude_async_void_methods = true
+# dotnet_code_quality.CA2007.skip_async_void_methods = true
+# dotnet_code_quality.CA2007.output_kind =
+
+# CA2008: Do not create tasks without passing a TaskScheduler
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2008
+# dotnet_diagnostic.CA2008.severity = default
+
+# CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2009
+# dotnet_diagnostic.CA2009.severity = default
+
+# CA2011: Do not assign property within its setter
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2011
+# dotnet_diagnostic.CA2011.severity = default
+
+# CA2012: Use ValueTasks correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2012
+# dotnet_diagnostic.CA2012.severity = default
+
+# CA2013: Do not use ReferenceEquals with value types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2013
+# dotnet_diagnostic.CA2013.severity = default
+
+# CA2014: Do not use stackalloc in loops
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2014
+# dotnet_diagnostic.CA2014.severity = default
+
+# CA2015: Do not define finalizers for types derived from MemoryManager<T>
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2015
+# dotnet_diagnostic.CA2015.severity = default
+
+# CA2016: Forward the CancellationToken parameter to methods that take one
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016
+# dotnet_diagnostic.CA2016.severity = default
+
+# CA2017: Parameter count mismatch
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017
+# dotnet_diagnostic.CA2017.severity = default
+
+# CA2018: The count argument to Buffer.BlockCopy should specify the number of bytes to copy
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018
+# dotnet_diagnostic.CA2018.severity = default
+
+# CA2019: ThreadStatic fields should not use inline initialization
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019
+# dotnet_diagnostic.CA2019.severity = default
+
+# CA2020: Prevent behavioral change caused by built-in operators of IntPtr/UIntPtr
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2020
+# dotnet_diagnostic.CA2020.severity = default
+
+# CA2021: Don't call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021
+# dotnet_diagnostic.CA2021.severity = default
+
+# CA2022: Avoid inexact read with Stream.Read
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2022
+# dotnet_diagnostic.CA2022.severity = default
+
+##########################################
+# Code Quality rules
+# Security rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/security-warnings
+##########################################
+[*.{cs,csx,cake}]
+
+# CA2100: Review SQL queries for security vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100
+# dotnet_diagnostic.CA2100.severity = default
+# dotnet_code_quality.CA2100.excluded_symbol_names =
+# dotnet_code_quality.CA2100.excluded_type_names_with_derived_types =
+
+# CA2109: Review visible event handlers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2109
+# dotnet_diagnostic.CA2109.severity = default
+
+# CA2119: Seal methods that satisfy private interfaces
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+# dotnet_diagnostic.CA2119.severity = default
+
+# CA2153: Avoid handling Corrupted State Exceptions
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2153
+# dotnet_diagnostic.CA2153.severity = default
+
+# CA2300: Do not use insecure deserializer BinaryFormatter
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2300
+# dotnet_diagnostic.CA2300.severity = default
+
+# CA2301: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2301
+# dotnet_diagnostic.CA2301.severity = default
+# dotnet_code_quality.CA2301.excluded_symbol_names =
+# dotnet_code_quality.CA2301.excluded_type_names_with_derived_types =
+
+# CA2302: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2302
+# dotnet_diagnostic.CA2302.severity = default
+# dotnet_code_quality.CA2302.excluded_symbol_names =
+# dotnet_code_quality.CA2302.excluded_type_names_with_derived_types =
+
+# CA2305: Do not use insecure deserializer LosFormatter
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2305
+# dotnet_diagnostic.CA2305.severity = default
+
+# CA2310: Do not use insecure deserializer NetDataContractSerializer
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2310
+# dotnet_diagnostic.CA2310.severity = default
+
+# CA2311: Do not deserialize without first setting NetDataContractSerializer.Binder
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2311
+# dotnet_diagnostic.CA2311.severity = default
+# dotnet_code_quality.CA2311.excluded_symbol_names =
+# dotnet_code_quality.CA2311.excluded_type_names_with_derived_types =
+
+# CA2312: Ensure NetDataContractSerializer.Binder is set before deserializing
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2312
+# dotnet_diagnostic.CA2312.severity = default
+# dotnet_code_quality.CA2312.excluded_symbol_names =
+# dotnet_code_quality.CA2312.excluded_type_names_with_derived_types =
+
+# CA2315: Do not use insecure deserializer ObjectStateFormatter
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2315
+# dotnet_diagnostic.CA2315.severity = default
+
+# CA2321: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2321
+# dotnet_diagnostic.CA2321.severity = default
+# dotnet_code_quality.CA2321.excluded_symbol_names =
+# dotnet_code_quality.CA2321.excluded_type_names_with_derived_types =
+
+# CA2322: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2322
+# dotnet_diagnostic.CA2322.severity = default
+# dotnet_code_quality.CA2322.excluded_symbol_names =
+# dotnet_code_quality.CA2322.excluded_type_names_with_derived_types =
+
+# CA2326: Do not use TypeNameHandling values other than None
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2326
+# dotnet_diagnostic.CA2326.severity = default
+
+# CA2327: Do not use insecure JsonSerializerSettings
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2327
+# dotnet_diagnostic.CA2327.severity = default
+# dotnet_code_quality.CA2327.excluded_symbol_names =
+# dotnet_code_quality.CA2327.excluded_type_names_with_derived_types =
+
+# CA2328: Ensure that JsonSerializerSettings are secure
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2328
+# dotnet_diagnostic.CA2328.severity = default
+# dotnet_code_quality.CA2328.excluded_symbol_names =
+# dotnet_code_quality.CA2328.excluded_type_names_with_derived_types =
+
+# CA2329: Do not deserialize with JsonSerializer using an insecure configuration
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2329
+# dotnet_diagnostic.CA2329.severity = default
+# dotnet_code_quality.CA2329.excluded_symbol_names =
+# dotnet_code_quality.CA2329.excluded_type_names_with_derived_types =
+
+# CA2330: Ensure that JsonSerializer has a secure configuration when deserializing
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2330
+# dotnet_diagnostic.CA2330.severity = default
+# dotnet_code_quality.CA2330.excluded_symbol_names =
+# dotnet_code_quality.CA2330.excluded_type_names_with_derived_types =
+
+# CA2350: Ensure DataTable.ReadXml()'s input is trusted
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2350
+# dotnet_diagnostic.CA2350.severity = default
+
+# CA2351: Ensure DataSet.ReadXml()'s input is trusted
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2351
+# dotnet_diagnostic.CA2351.severity = default
+
+# CA2352: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2352
+# dotnet_diagnostic.CA2352.severity = default
+
+# CA2353: Unsafe DataSet or DataTable in serializable type
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2353
+# dotnet_diagnostic.CA2353.severity = default
+
+# CA2354: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attack
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2354
+# dotnet_diagnostic.CA2354.severity = default
+
+# CA2355: Unsafe DataSet or DataTable in deserialized object graph
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2355
+# dotnet_diagnostic.CA2355.severity = default
+
+# CA2356: Unsafe DataSet or DataTable type in web deserialized object graph
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2356
+# dotnet_diagnostic.CA2356.severity = default
+
+# CA2361: Ensure autogenerated class containing DataSet.ReadXml() is not used with untrusted data
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2361
+# dotnet_diagnostic.CA2361.severity = default
+
+# CA2362: Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2362
+# dotnet_diagnostic.CA2362.severity = default
+
+# CA3001: Review code for SQL injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3001
+# dotnet_diagnostic.CA3001.severity = default
+# dotnet_code_quality.CA3001.excluded_symbol_names =
+# dotnet_code_quality.CA3001.excluded_type_names_with_derived_types =
+
+# CA3002: Review code for XSS vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3002
+# dotnet_diagnostic.CA3002.severity = default
+# dotnet_code_quality.CA3002.excluded_symbol_names =
+# dotnet_code_quality.CA3002.excluded_type_names_with_derived_types =
+
+# CA3003: Review code for file path injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3003
+# dotnet_diagnostic.CA3003.severity = default
+# dotnet_code_quality.CA3003.excluded_symbol_names =
+# dotnet_code_quality.CA3003.excluded_type_names_with_derived_types =
+
+# CA3004: Review code for information disclosure vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3004
+# dotnet_diagnostic.CA3004.severity = default
+# dotnet_code_quality.CA3004.excluded_symbol_names =
+# dotnet_code_quality.CA3004.excluded_type_names_with_derived_types =
+
+# CA3005: Review code for LDAP injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3005
+# dotnet_diagnostic.CA3005.severity = default
+# dotnet_code_quality.CA3005.excluded_symbol_names =
+# dotnet_code_quality.CA3005.excluded_type_names_with_derived_types =
+
+# CA3006: Review code for process command injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3006
+# dotnet_diagnostic.CA3006.severity = default
+# dotnet_code_quality.CA3006.excluded_symbol_names =
+# dotnet_code_quality.CA3006.excluded_type_names_with_derived_types =
+
+# CA3007: Review code for open redirect vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3007
+# dotnet_diagnostic.CA3007.severity = default
+# dotnet_code_quality.CA3007.excluded_symbol_names =
+# dotnet_code_quality.CA3007.excluded_type_names_with_derived_types =
+
+# CA3008: Review code for XPath injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3008
+# dotnet_diagnostic.CA3008.severity = default
+# dotnet_code_quality.CA3008.excluded_symbol_names =
+# dotnet_code_quality.CA3008.excluded_type_names_with_derived_types =
+
+# CA3009: Review code for XML injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3009
+# dotnet_diagnostic.CA3009.severity = default
+# dotnet_code_quality.CA3009.excluded_symbol_names =
+# dotnet_code_quality.CA3009.excluded_type_names_with_derived_types =
+
+# CA3010: Review code for XAML injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3010
+# dotnet_diagnostic.CA3010.severity = default
+# dotnet_code_quality.CA3010.excluded_symbol_names =
+# dotnet_code_quality.CA3010.excluded_type_names_with_derived_types =
+
+# CA3011: Review code for DLL injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3011
+# dotnet_diagnostic.CA3011.severity = default
+# dotnet_code_quality.CA3011.excluded_symbol_names =
+# dotnet_code_quality.CA3011.excluded_type_names_with_derived_types =
+
+# CA3012: Review code for regex injection vulnerabilities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3012
+# dotnet_diagnostic.CA3012.severity = default
+# dotnet_code_quality.CA3012.excluded_symbol_names =
+# dotnet_code_quality.CA3012.excluded_type_names_with_derived_types =
+
+# CA3061: Do not add schema by URL
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3061
+# dotnet_diagnostic.CA3061.severity = default
+
+# CA3075: Insecure DTD Processing
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3075
+# dotnet_diagnostic.CA3075.severity = default
+
+# CA3076: Insecure XSLT Script Execution
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3076
+# dotnet_diagnostic.CA3076.severity = default
+
+# CA3077: Insecure Processing in API Design, XML Document and XML Text Reader
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3077
+# dotnet_diagnostic.CA3077.severity = default
+
+# CA3147: Mark verb handlers with ValidateAntiForgeryToken
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca3147
+# dotnet_diagnostic.CA3147.severity = default
+
+# CA5350: Do Not Use Weak Cryptographic Algorithms
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5350
+# dotnet_diagnostic.CA5350.severity = default
+
+# CA5351 Do Not Use Broken Cryptographic Algorithms
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351
+# dotnet_diagnostic.CA5351.severity = default
+
+# CA5358: Do Not Use Unsafe Cipher Modes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358
+# dotnet_diagnostic.CA5358.severity = default
+
+# CA5359: Do not disable certificate validation
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5359
+# dotnet_diagnostic.CA5359.severity = default
+
+# CA5360: Do not call dangerous methods in deserialization
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360
+# dotnet_diagnostic.CA5360.severity = default
+
+# CA5361: Do not disable SChannel use of strong crypto
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5361
+# dotnet_diagnostic.CA5361.severity = default
+# dotnet_code_quality.CA5361.excluded_symbol_names =
+# dotnet_code_quality.CA5361.excluded_type_names_with_derived_types =
+
+# CA5362: Potential reference cycle in deserialized object graph
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5362
+# dotnet_diagnostic.CA5362.severity = default
+
+# CA5363: Do not disable request validation
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5363
+# dotnet_diagnostic.CA5363.severity = default
+
+# CA5364: Do not use deprecated security protocols
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5364
+# dotnet_diagnostic.CA5364.severity = default
+
+# CA5365: Do Not Disable HTTP Header Checking
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5365
+# dotnet_diagnostic.CA5365.severity = default
+
+# CA5366: Use XmlReader For DataSet Read XML
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5366
+# dotnet_diagnostic.CA5366.severity = default
+
+# CA5367: Do not serialize types with pointer fields
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5367
+# dotnet_diagnostic.CA5367.severity = default
+
+# CA5368: Set ViewStateUserKey For Classes Derived From Page
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5368
+# dotnet_diagnostic.CA5368.severity = default
+
+# CA5369: Use XmlReader for Deserialize
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5369
+# dotnet_diagnostic.CA5369.severity = default
+
+# CA5370: Use XmlReader for validating reader
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5370
+# dotnet_diagnostic.CA5370.severity = default
+
+# CA5371: Use XmlReader for schema read
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5371
+# dotnet_diagnostic.CA5371.severity = default
+
+# CA5372: Use XmlReader for XPathDocument
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5372
+# dotnet_diagnostic.CA5372.severity = default
+
+# CA5373: Do not use obsolete key derivation function
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5373
+# dotnet_diagnostic.CA5373.severity = default
+
+# CA5374: Do not use XslTransform
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5374
+# dotnet_diagnostic.CA5374.severity = default
+
+# CA5375: Do not use account shared access signature
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5375
+# dotnet_diagnostic.CA5375.severity = default
+
+# CA5376: Use SharedAccessProtocol HttpsOnly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5376
+# dotnet_diagnostic.CA5376.severity = default
+# dotnet_code_quality.CA5376.excluded_symbol_names =
+# dotnet_code_quality.CA5376.excluded_type_names_with_derived_types =
+
+# CA5377: Use container level access policy
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5377
+# dotnet_diagnostic.CA5377.severity = default
+# dotnet_code_quality.CA5377.excluded_symbol_names =
+# dotnet_code_quality.CA5377.excluded_type_names_with_derived_types =
+
+# CA5378: Do not disable ServicePointManagerSecurityProtocols
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5378
+# dotnet_diagnostic.CA5378.severity = default
+# dotnet_code_quality.CA5378.excluded_symbol_names =
+# dotnet_code_quality.CA5378.excluded_type_names_with_derived_types =
+
+# CA5379: Ensure key derivation function algorithm is sufficiently strong
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5379
+# dotnet_diagnostic.CA5379.severity = default
+
+# CA5380: Do not add certificates to root store
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5380
+# dotnet_diagnostic.CA5380.severity = default
+# dotnet_code_quality.CA5380.excluded_symbol_names =
+# dotnet_code_quality.CA5380.excluded_type_names_with_derived_types =
+
+# CA5381: Ensure certificates are not added to root store
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5381
+# dotnet_diagnostic.CA5381.severity = default
+# dotnet_code_quality.CA5381.excluded_symbol_names =
+# dotnet_code_quality.CA5381.excluded_type_names_with_derived_types =
+
+# CA5382: Use secure cookies in ASP.NET Core
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5382
+# dotnet_diagnostic.CA5382.severity = default
+# dotnet_code_quality.CA5382.excluded_symbol_names =
+# dotnet_code_quality.CA5382.excluded_type_names_with_derived_types =
+
+# CA5383: Ensure use secure cookies in ASP.NET Core
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5383
+# dotnet_diagnostic.CA5383.severity = default
+# dotnet_code_quality.CA5383.excluded_symbol_names =
+# dotnet_code_quality.CA5383.excluded_type_names_with_derived_types =
+
+# CA5384: Do not use digital signature algorithm (DSA)
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5384
+# dotnet_diagnostic.CA5384.severity = default
+# dotnet_code_quality.CA5384.excluded_symbol_names =
+# dotnet_code_quality.CA5384.excluded_type_names_with_derived_types =
+
+# CA5385: Use Rivest–Shamir–Adleman (RSA) algorithm with sufficient key size
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5385
+# dotnet_diagnostic.CA5385.severity = default
+
+# CA5386: Avoid hardcoding SecurityProtocolType value
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5386
+# dotnet_diagnostic.CA5386.severity = default
+
+# CA5387: Do not use weak key derivation function with insufficient iteration count
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5387
+# dotnet_diagnostic.CA5387.severity = default
+# dotnet_code_quality.CA5387.excluded_symbol_names =
+# dotnet_code_quality.CA5387.excluded_type_names_with_derived_types =
+
+# CA5388: Ensure sufficient iteration count when using weak key derivation function
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5388
+# dotnet_diagnostic.CA5388.severity = default
+# dotnet_code_quality.CA5388.excluded_symbol_names =
+# dotnet_code_quality.CA5388.excluded_type_names_with_derived_types =
+
+# CA5389: Do not add archive item's path to the target file system path
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5389
+# dotnet_diagnostic.CA5389.severity = default
+# dotnet_code_quality.CA5389.excluded_symbol_names =
+# dotnet_code_quality.CA5389.excluded_type_names_with_derived_types =
+
+# CA5390: Do not hard-code encryption key
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5390
+# dotnet_diagnostic.CA5390.severity = default
+# dotnet_code_quality.CA5390.excluded_symbol_names =
+# dotnet_code_quality.CA5390.excluded_type_names_with_derived_types =
+
+# CA5391: Use antiforgery tokens in ASP.NET Core MVC controllers
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5391
+# dotnet_diagnostic.CA5391.severity = default
+# dotnet_code_quality.CA5391.exclude_aspnet_core_mvc_controllerbase = true
+
+# CA5392: Use DefaultDllImportSearchPaths attribute for P/Invokes
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5392
+# dotnet_diagnostic.CA5392.severity = default
+
+# CA5393: Do not use unsafe DllImportSearchPath value
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5393
+# dotnet_diagnostic.CA5393.severity = default
+# dotnet_code_quality.CA5393.unsafe_DllImportSearchPath_bits = 770
+
+# CA5394: Do not use insecure randomness
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5394
+# dotnet_diagnostic.CA5394.severity = default
+
+# CA5395: Miss HttpVerb attribute for action methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5395
+# dotnet_diagnostic.CA5395.severity = default
+
+# CA5396: Set HttpOnly to true for HttpCookie
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5396
+# dotnet_diagnostic.CA5396.severity = default
+
+# CA5397: Do not use deprecated SslProtocols values
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5397
+# dotnet_diagnostic.CA5397.severity = default
+
+# CA5398: Avoid hardcoded SslProtocols values
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5398
+# dotnet_diagnostic.CA5398.severity = default
+
+# CA5399: Enable HttpClient certificate revocation list check
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5399
+# dotnet_diagnostic.CA5399.severity = default
+# dotnet_code_quality.CA5399.excluded_symbol_names =
+# dotnet_code_quality.CA5399.excluded_type_names_with_derived_types =
+
+# CA5400: Ensure HttpClient certificate revocation list check is not disabled
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5400
+# dotnet_diagnostic.CA5400.severity = default
+# dotnet_code_quality.CA5400.excluded_symbol_names =
+# dotnet_code_quality.CA5400.excluded_type_names_with_derived_types =
+
+# CA5401: Do not use CreateEncryptor with non-default IV
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5401
+# dotnet_diagnostic.CA5401.severity = default
+
+# CA5402: Use CreateEncryptor with the default IV
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5402
+# dotnet_diagnostic.CA5402.severity = default
+
+# CA5403: Do not hard-code certificate
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5403
+# dotnet_diagnostic.CA5403.severity = default
+
+# CA5404: Do not disable token validation checks
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5404
+# dotnet_diagnostic.CA5404.severity = default
+
+# CA5405: Do not always skip token validation in delegates
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5405
+# dotnet_diagnostic.CA5405.severity = default
+
+##########################################
+# Code Quality rules
+# Usage rules
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/usage-warnings
+##########################################
+[*.{cs,csx,cake}]
+
+# CA1801: Review unused parameters
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1801
+# dotnet_diagnostic.CA1801.severity = default
+# dotnet_code_quality.CA1801.api_surface = all
+
+# CA1816: Call GC.SuppressFinalize correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1816
+# dotnet_diagnostic.CA1816.severity = default
+
+# CA2200: Rethrow to preserve stack details
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2200
+# dotnet_diagnostic.CA2200.severity = default
+
+# CA2201: Do not raise reserved exception types
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
+# dotnet_diagnostic.CA2201.severity = default
+
+# CA2207: Initialize value type static fields inline
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2207
+# dotnet_diagnostic.CA2207.severity = default
+
+# CA2208: Instantiate argument exceptions correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208
+# dotnet_diagnostic.CA2208.severity = default
+# dotnet_code_quality.CA2208.api_surface = all
+
+# CA2211: Non-constant fields should not be visible
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2211
+# dotnet_diagnostic.CA2211.severity = default
+
+# CA2213: Disposable fields should be disposed
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2213
+# dotnet_diagnostic.CA2213.severity = default
+
+# CA2214: Do not call overridable methods in constructors
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214
+# dotnet_diagnostic.CA2214.severity = default
+
+# CA2215: Dispose methods should call base class dispose
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2215
+# dotnet_diagnostic.CA2215.severity = default
+
+# CA2216: Disposable types should declare finalizer
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2216
+# dotnet_diagnostic.CA2216.severity = default
+
+# CA2217: Do not mark enums with FlagsAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217
+# dotnet_diagnostic.CA2217.severity = default
+# dotnet_code_quality.CA2217.api_surface = all
+
+# CA2218: Override GetHashCode on overriding Equals
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2218
+# dotnet_diagnostic.CA2218.severity = default
+
+# CA2219: Do not raise exceptions in exception clauses
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2219
+# dotnet_diagnostic.CA2219.severity = default
+
+# CA2224: Override Equals on overloading operator equals
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2224
+# dotnet_diagnostic.CA2224.severity = default
+
+# CA2225: Operator overloads have named alternates
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225
+# dotnet_diagnostic.CA2225.severity = default
+# dotnet_code_quality.CA2225.api_surface = all
+
+# CA2226: Operators should have symmetrical overloads
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2226
+# dotnet_diagnostic.CA2226.severity = default
+# dotnet_code_quality.CA2226.api_surface = all
+
+# CA2227: Collection properties should be read only
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+# dotnet_diagnostic.CA2227.severity = default
+
+# CA2229: Implement serialization constructors
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2229
+# dotnet_diagnostic.CA2229.severity = default
+
+# CA2231: Overload operator equals on overriding ValueType.Equals
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
+# dotnet_diagnostic.CA2231.severity = default
+# dotnet_code_quality.CA2231.api_surface = all
+
+# CA2234: Pass System.Uri objects instead of strings
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2234
+# dotnet_diagnostic.CA2234.severity = default
+# dotnet_code_quality.CA2234.api_surface = all
+
+# CA2235: Mark all non-serializable fields
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2235
+# dotnet_diagnostic.CA2235.severity = default
+
+# CA2237: Mark ISerializable types with SerializableAttribute
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2237
+# dotnet_diagnostic.CA2237.severity = default
+
+# CA2241: Provide correct arguments to formatting methods
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2241
+# dotnet_diagnostic.CA2241.severity = default
+# dotnet_code_quality.CA2241.additional_string_formatting_methods =
+
+# CA2242: Test for NaN correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2242
+# dotnet_diagnostic.CA2242.severity = default
+
+# CA2243: Attribute string literals should parse correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2243
+# dotnet_diagnostic.CA2243.severity = default
+
+# CA2244: Do not duplicate indexed element initializations
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2244
+# dotnet_diagnostic.CA2244.severity = default
+
+# CA2245: Do not assign a property to itself
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2245
+# dotnet_diagnostic.CA2245.severity = default
+
+# CA2246: Do not assign a symbol and its member in the same statement
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2246
+# dotnet_diagnostic.CA2246.severity = default
+
+# CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2247
+# dotnet_diagnostic.CA2247.severity = default
+
+# CA2248: Provide correct enum argument to Enum.HasFlag
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2248
+# dotnet_diagnostic.CA2248.severity = default
+
+# CA2249: Consider using String.Contains instead of String.IndexOf
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2249
+# dotnet_diagnostic.CA2249.severity = default
+
+# CA2250: Use ThrowIfCancellationRequested
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250
+# dotnet_diagnostic.CA2250.severity = default
+
+# CA2251: Use String.Equals over String.Compare
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251
+# dotnet_diagnostic.CA2251.severity = default
+
+# CA2252: Opt in to preview features before using them
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252
+# dotnet_diagnostic.CA2252.severity = default
+
+# CA2253: Named placeholders should not be numeric values
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253
+# dotnet_diagnostic.CA2253.severity = default
+
+# CA2254: Template should be a static expression
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254
+# dotnet_diagnostic.CA2254.severity = default
+
+# CA2255: The ModuleInitializer attribute should not be used in libraries
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255
+# dotnet_diagnostic.CA2255.severity = default
+
+# CA2256: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2256
+# dotnet_diagnostic.CA2256.severity = default
+
+# CA2257: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2257
+# dotnet_diagnostic.CA2257.severity = default
+
+# CA2258: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2258
+# dotnet_diagnostic.CA2258.severity = default
+
+# CA2259: Ensure ThreadStatic is only used with static fields
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259
+# dotnet_diagnostic.CA2259.severity = default
+
+# CA2260: Implement generic math interfaces correctly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2260
+# dotnet_diagnostic.CA2260.severity = default
+
+# CA2261: Do not use ConfigureAwaitOptions.SuppressThrowing with Task<TResult>
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2261
+# dotnet_diagnostic.CA2261.severity = default
+
+# CA2262: Set 'MaxResponseHeadersLength' properly
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2262
+# dotnet_diagnostic.CA2262.severity = default
+
+# CA2263: Prefer generic overload when type is known
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2263
+# dotnet_diagnostic.CA2263.severity = default
+
+# CA2264: Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull'
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2264
+# dotnet_diagnostic.CA2264.severity = default
+
+# CA2265: Do not compare Span<T> to null or default
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2265
+# dotnet_diagnostic.CA2265.severity = default
+
+##########################################
+# StyleCop Analyzers
+# Special Rules (SA0000-)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SpecialRules.md
+##########################################
+[*.{cs,csx,cake}]
+
+# Xml Comment Analysis Disabled (SA0001)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md
+# dotnet_diagnostic.SA0001.severity = default
+
+# Invalid Settings File (SA0002)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0002.md
+# dotnet_diagnostic.SA0002.severity = default
+
+##########################################
+# StyleCop Analyzers
+# Spacing Rules (SA1000-)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SpacingRules.md
+##########################################
+[*.{cs,csx,cake}]
+
+# KeywordsMustBeSpacedCorrectly (SA1000)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md
+# dotnet_diagnostic.SA1000.severity = default
+
+# CommasMustBeSpacedCorrectly (SA1001)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+# dotnet_diagnostic.SA1001.severity = default
+
+# SemicolonsMustBeSpacedCorrectly (SA1002)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md
+# dotnet_diagnostic.SA1002.severity = default
+
+# SymbolsMustBeSpacedCorrectly (SA1003)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1003.md
+# dotnet_diagnostic.SA1003.severity = default
+
+# DocumentationLinesMustBeginWithSingleSpace (SA1004)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1004.md
+# dotnet_diagnostic.SA1004.severity = default
+
+# SingleLineCommentsMustBeginWithSingleSpace (SA1005)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
+# dotnet_diagnostic.SA1005.severity = default
+
+# PreprocessorKeywordsMustNotBePrecededBySpace (SA1006)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1006.md
+# dotnet_diagnostic.SA1006.severity = default
+
+# OperatorKeywordMustBeFollowedBySpace (SA1007)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1007.md
+# dotnet_diagnostic.SA1007.severity = default
+
+# OpeningParenthesisMustBeSpacedCorrectly (SA1008)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+# dotnet_diagnostic.SA1008.severity = default
+
+# ClosingParenthesisMustBeSpacedCorrectly (SA1009)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+# dotnet_diagnostic.SA1009.severity = default
+
+# OpeningSquareBracketsMustBeSpacedCorrectly (SA1010)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md
+# dotnet_diagnostic.SA1010.severity = default
+
+# ClosingSquareBracketsMustBeSpacedCorrectly (SA1011)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+# dotnet_diagnostic.SA1011.severity = default
+
+# OpeningBracesMustBeSpacedCorrectly (SA1012)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+# dotnet_diagnostic.SA1012.severity = default
+
+# ClosingBracesMustBeSpacedCorrectly (SA1013)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# dotnet_diagnostic.SA1013.severity = default
+
+# OpeningGenericBracketsMustBeSpacedCorrectly (SA1014)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md
+# dotnet_diagnostic.SA1014.severity = default
+
+# ClosingGenericBracketsMustBeSpacedCorrectly (SA1015)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md
+# dotnet_diagnostic.SA1015.severity = default
+
+# OpeningAttributeBracketsMustBeSpacedCorrectly (SA1016)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1016.md
+# dotnet_diagnostic.SA1016.severity = default
+
+# ClosingAttributeBracketsMustBeSpacedCorrectly (SA1017)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1017.md
+# dotnet_diagnostic.SA1017.severity = default
+
+# NullableTypeSymbolsMustNotBePrecededBySpace (SA1018)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1018.md
+# dotnet_diagnostic.SA1018.severity = default
+
+# MemberAccessSymbolsMustBeSpacedCorrectly (SA1019)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md
+# dotnet_diagnostic.SA1019.severity = default
+
+# IncrementDecrementSymbolsMustBeSpacedCorrectly (SA1020)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md
+# dotnet_diagnostic.SA1020.severity = default
+
+# NegativeSignsMustBeSpacedCorrectly (SA1021)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md
+# dotnet_diagnostic.SA1021.severity = default
+
+# PositiveSignsMustBeSpacedCorrectly (SA1022)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md
+# dotnet_diagnostic.SA1022.severity = default
+
+# DereferenceAndAccessOfMustBeSpacedCorrectly (SA1023)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md
+# dotnet_diagnostic.SA1023.severity = default
+
+# ColonsMustBeSpacedCorrectly (SA1024)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md
+# dotnet_diagnostic.SA1024.severity = default
+
+# CodeMustNotContainMultipleWhitespaceInARow (SA1025)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1025.md
+# dotnet_diagnostic.SA1025.severity = default
+
+# CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation (SA1026)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+# dotnet_diagnostic.SA1026.severity = default
+
+# UseTabsCorrectly (SA1027)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1027.md
+# dotnet_diagnostic.SA1027.severity = default
+
+# CodeMustNotContainTrailingWhitespace (SA1028)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md
+# dotnet_diagnostic.SA1028.severity = default
+
+##########################################
+# StyleCop Analyzers
+# Readability Rules (SA1100-)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SpacingRules.md
+##########################################
+[*.{cs,csx,cake}]
+
+# DoNotPrefixCallsWithBaseUnlessLocalImplementationExists (SA1100)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1100.md
+# dotnet_diagnostic.SA1100.severity = default
+
+# PrefixLocalCallsWithThis (SA1101)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
 dotnet_diagnostic.SA1101.severity = none
 
-# SA1200: Using directives should be placed correctly
+# Query clause should follow previous clause (SA1102)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md
+# dotnet_diagnostic.SA1102.severity = default
+
+# Query clauses should be on separate lines or all on one line (SA1103)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md
+# dotnet_diagnostic.SA1103.severity = default
+
+# Query clause should begin on new line when previous clause spans multiple lines (SA1104)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md
+# dotnet_diagnostic.SA1104.severity = default
+
+# Query clauses spanning multiple lines should begin on own line (SA1105)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
+# dotnet_diagnostic.SA1105.severity = default
+
+# CodeMustNotContainEmptyStatements (SA1106)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1106.md
+# dotnet_diagnostic.SA1106.severity = default
+
+# CodeMustNotContainMultipleStatementsOnOneLine (SA1107)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1107.md
+# dotnet_diagnostic.SA1107.severity = default
+
+# BlockStatementsMustNotContainEmbeddedComments (SA1108)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
+# dotnet_diagnostic.SA1108.severity = default
+
+# BlockStatementsMustNotContainEmbeddedRegions (SA1109)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1109.md
+# dotnet_diagnostic.SA1109.severity = default
+
+# OpeningParenthesisMustBeOnDeclarationLine (SA1110)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1110.md
+# dotnet_diagnostic.SA1110.severity = default
+
+# ClosingParenthesisMustBeOnLineOfLastParameter (SA1111)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1111.md
+# dotnet_diagnostic.SA1111.severity = default
+
+# ClosingParenthesisMustBeOnLineOfOpeningParenthesis (SA1112)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1112.md
+# dotnet_diagnostic.SA1112.severity = default
+
+# CommaMustBeOnSameLineAsPreviousParameter (SA1113)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1113.md
+# dotnet_diagnostic.SA1113.severity = default
+
+# ParameterListMustFollowDeclaration (SA1114)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
+# dotnet_diagnostic.SA1114.severity = default
+
+# ParameterMustFollowComma (SA1115)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1115.md
+# dotnet_diagnostic.SA1115.severity = default
+
+# SplitParametersMustStartOnLineAfterDeclaration (SA1116)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1116.md
+# dotnet_diagnostic.SA1116.severity = default
+
+# ParametersMustBeOnSameLineOrSeparateLines (SA1117)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
+# dotnet_diagnostic.SA1117.severity = default
+
+# ParameterMustNotSpanMultipleLines (SA1118)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
+# dotnet_diagnostic.SA1118.severity = default
+
+# CommentsMustContainText (SA1120)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1120.md
+# dotnet_diagnostic.SA1120.severity = default
+
+# UseBuiltInTypeAlias (SA1121)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md
+# dotnet_diagnostic.SA1121.severity = default
+
+# UseStringEmptyForEmptyStrings (SA1122)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md
+# dotnet_diagnostic.SA1122.severity = default
+
+# DoNotPlaceRegionsWithinElements (SA1123)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1123.md
+# dotnet_diagnostic.SA1123.severity = default
+
+# DoNotUseRegions (SA1124)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
+# dotnet_diagnostic.SA1124.severity = default
+
+# UseShorthandForNullableTypes (SA1125)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1125.md
+# dotnet_diagnostic.SA1125.severity = default
+
+# PrefixCallsCorrectly (SA1126)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1126.md
+# dotnet_diagnostic.SA1126.severity = default
+
+# GenericTypeConstraintsMustBeOnOwnLine (SA1127)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1127.md
+# dotnet_diagnostic.SA1127.severity = default
+
+# ConstructorInitializerMustBeOnOwnLine (SA1128)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md
+# dotnet_diagnostic.SA1128.severity = default
+
+# DoNotUseDefaultValueTypeConstructor (SA1129)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md
+# dotnet_diagnostic.SA1129.severity = default
+
+# UseLambdaSyntax (SA1130)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1130.md
+# dotnet_diagnostic.SA1130.severity = default
+
+# UseReadableConditions (SA1131)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md
+# dotnet_diagnostic.SA1131.severity = default
+
+# DoNotCombineFields (SA1132)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1132.md
+# dotnet_diagnostic.SA1132.severity = default
+
+# DoNotCombineAttributes (SA1133)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md
+# dotnet_diagnostic.SA1133.severity = default
+
+# AttributesMustNotShareLine (SA1134)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md
+# dotnet_diagnostic.SA1134.severity = default
+
+# UsingDirectivesMustBeQualified (SA1135)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
+# dotnet_diagnostic.SA1135.severity = default
+
+# EnumValuesShouldBeOnSeparateLines (SA1136)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1136.md
+# dotnet_diagnostic.SA1136.severity = default
+
+# ElementsShouldHaveTheSameIndentation (SA1137)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
+# dotnet_diagnostic.SA1137.severity = default
+
+# UseLiteralsSuffixNotationInsteadOfCasting (SA1139)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1139.md
+# dotnet_diagnostic.SA1139.severity = default
+
+# UseTupleSyntax (SA1141)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1141.md
+# dotnet_diagnostic.SA1141.severity = default
+
+# ReferToTupleElementsByName (SA1142)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+# dotnet_diagnostic.SA1142.severity = default
+
+##########################################
+# StyleCop Analyzers
+# Ordering Rules (SA1200-)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/OrderingRules.md
+##########################################
+[*.{cs,csx,cake}]
+
+# UsingDirectivesMustBePlacedCorrectly (SA1200)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
 dotnet_diagnostic.SA1200.severity = none
 
-# SA1633: The file header is missing or not located at the top of the file
+# ElementsMustAppearInTheCorrectOrder (SA1201)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
+# dotnet_diagnostic.SA1201.severity = default
+
+# ElementsMustBeOrderedByAccess (SA1202)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
+# dotnet_diagnostic.SA1202.severity = default
+
+# ConstantsMustAppearBeforeFields (SA1203)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
+# dotnet_diagnostic.SA1203.severity = default
+
+# StaticElementsMustAppearBeforeInstanceElements (SA1204)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
+# dotnet_diagnostic.SA1204.severity = default
+
+# PartialElementsMustDeclareAccess (SA1205)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md
+# dotnet_diagnostic.SA1205.severity = default
+
+# DeclarationKeywordsMustFollowOrder (SA1206)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
+# dotnet_diagnostic.SA1206.severity = default
+
+# ProtectedMustComeBeforeInternal (SA1207)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
+# dotnet_diagnostic.SA1207.severity = default
+
+# SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectives (SA1208)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
+# dotnet_diagnostic.SA1208.severity = default
+
+# UsingAliasDirectivesMustBePlacedAfterOtherUsingDirectives (SA1209)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md
+# dotnet_diagnostic.SA1209.severity = default
+
+# UsingDirectivesMustBeOrderedAlphabeticallyByNamespace (SA1210)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
+# dotnet_diagnostic.SA1210.severity = default
+
+# UsingAliasDirectivesMustBeOrderedAlphabeticallyByAliasName
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1211.md
+# dotnet_diagnostic.SA1211.severity = default
+
+# PropertyAccessorsMustFollowOrder (SA1212)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md
+# dotnet_diagnostic.SA1212.severity = default
+
+# EventAccessorsMustFollowOrder (SA1213)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md
+# dotnet_diagnostic.SA1213.severity = default
+
+# ReadonlyElementsMustAppearBeforeNonReadonlyElements (SA1214)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
+# dotnet_diagnostic.SA1214.severity = default
+
+# InstanceReadonlyElementsMustAppearBeforeInstanceNonReadonlyElements (SA1215)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1215.md
+# dotnet_diagnostic.SA1215.severity = default
+
+# UsingStaticDirectivesMustBePlacedAtTheCorrectLocation (SA1216)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
+# dotnet_diagnostic.SA1216.severity = default
+
+# UsingStaticDirectivesMustBeOrderedAlphabetically (SA1217)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1217.md
+# dotnet_diagnostic.SA1217.severity = default
+
+##########################################
+# StyleCop Analyzers
+# Naming Rules (SA1300-)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/NamingRules.md
+##########################################
+[*.{cs,csx,cake}]
+
+# ElementMustBeginWithUpperCaseLetter (SA1300)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# dotnet_diagnostic.SA1300.severity = default
+
+# ElementMustBeginWithLowerCaseLetter (SA1301)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1301.md
+# dotnet_diagnostic.SA1301.severity = default
+
+# InterfaceNamesMustBeginWithI (SA1302)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1302.md
+# dotnet_diagnostic.SA1302.severity = default
+
+# ConstFieldNamesMustBeginWithUpperCaseLetter (SA1303)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+# dotnet_diagnostic.SA1303.severity = default
+
+# NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter (SA1304)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1304.md
+# dotnet_diagnostic.SA1304.severity = default
+
+# FieldNamesMustNotUseHungarianNotation (SA1305)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1305.md
+# dotnet_diagnostic.SA1305.severity = default
+
+# FieldNamesMustBeginWithLowerCaseLetter (SA1306)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+# dotnet_diagnostic.SA1306.severity = default
+
+# AccessibleFieldsMustBeginWithUpperCaseLetter (SA1307)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1307.md
+# dotnet_diagnostic.SA1307.severity = default
+
+# VariableNamesMustNotBePrefixed (SA1308)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1308.md
+# dotnet_diagnostic.SA1308.severity = default
+
+# FieldNamesMustNotBeginWithUnderscore (SA1309)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1309.md
+# dotnet_diagnostic.SA1309.severity = default
+
+# FieldNamesMustNotContainUnderscores (SA1310)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1310.md
+# dotnet_diagnostic.SA1310.severity = default
+
+# StaticReadonlyFieldsMustBeginWithUpperCaseLetter (SA1311)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+# dotnet_diagnostic.SA1311.severity = default
+
+# VariableNamesMustBeginWithLowerCaseLetter (SA1312)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+# dotnet_diagnostic.SA1312.severity = default
+
+# ParameterNamesMustBeginWithLowerCaseLetter (SA1313)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md
+# dotnet_diagnostic.SA1313.severity = default
+
+# TypeParameterNamesMustBeginWithT (SA1314)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1314.md
+# dotnet_diagnostic.SA1314.severity = default
+
+# TupleElementNamesShouldUseCorrectCasing (SA1316)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
+# dotnet_diagnostic.SA1316.severity = default
+
+##########################################
+# StyleCop Analyzers
+# Maintainability Rules (SA1400-)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/MaintainabilityRules.md
+##########################################
+[*.{cs,csx,cake}]
+
+# StatementMustNotUseUnnecessaryParenthesis (SA1119)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1119.md
+# dotnet_diagnostic.SA1119.severity = default
+
+# AccessModifierMustBeDeclared (SA1400)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1400.md
+# dotnet_diagnostic.SA1400.severity = default
+
+# FieldsMustBePrivate (SA1401)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+# dotnet_diagnostic.SA1401.severity = default
+
+# FileMayOnlyContainASingleType (SA1402)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1402.md
+# dotnet_diagnostic.SA1402.severity = default
+
+# FileMayOnlyContainASingleNamespace (SA1403)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1403.md
+# dotnet_diagnostic.SA1403.severity = default
+
+# CodeAnalysisSuppressionMustHaveJustification (SA1404)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1404.md
+# dotnet_diagnostic.SA1404.severity = default
+
+# DebugAssertMustProvideMessageText (SA1405)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1405.md
+# dotnet_diagnostic.SA1405.severity = default
+
+# DebugFailMustProvideMessageText (SA1406)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1406.md
+# dotnet_diagnostic.SA1406.severity = default
+
+# ArithmeticExpressionsMustDeclarePrecedence (SA1407)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1407.md
+# dotnet_diagnostic.SA1407.severity = default
+
+# ConditionalExpressionsMustDeclarePrecedence (SA1408)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1408.md
+# dotnet_diagnostic.SA1408.severity = default
+
+# RemoveUnnecessaryCode (SA1409)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1409.md
+# dotnet_diagnostic.SA1409.severity = default
+
+# RemoveDelegateParenthesisWhenPossible (SA1410)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1410.md
+# dotnet_diagnostic.SA1410.severity = default
+
+# AttributeConstructorMustNotUseUnnecessaryParenthesis (SA1411)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md
+# dotnet_diagnostic.SA1411.severity = default
+
+# StoreFilesAsUtf8 (SA1412)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1412.md
+# dotnet_diagnostic.SA1412.severity = default
+
+# UseTrailingCommasInMultiLineInitializers (SA1413)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
+# dotnet_diagnostic.SA1413.severity = default
+
+# TupleTypesInSignaturesShouldHaveElementNames (SA1414)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
+# dotnet_diagnostic.SA1414.severity = default
+
+##########################################
+# StyleCop Analyzers
+# Layout Rules (SA1500-)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/LayoutRules.md
+##########################################
+[*.{cs,csx,cake}]
+
+# BracesForMultiLineStatementsMustNotShareLine (SA1500)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
+# dotnet_diagnostic.SA1500.severity = default
+
+# StatementMustNotBeOnSingleLine (SA1501)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1501.md
+# dotnet_diagnostic.SA1501.severity = default
+
+# ElementMustNotBeOnSingleLine (SA1502)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1502.md
+# dotnet_diagnostic.SA1502.severity = default
+
+# BracesMustNotBeOmitted (SA1503)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md
+# dotnet_diagnostic.SA1503.severity = default
+
+# AllAccessorsMustBeSingleLineOrMultiLine (SA1504)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1504.md
+# dotnet_diagnostic.SA1504.severity = default
+
+# OpeningBracesMustNotBeFollowedByBlankLine (SA1505)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md
+# dotnet_diagnostic.SA1505.severity = default
+
+# ElementDocumentationHeadersMustNotBeFollowedByBlankLine (SA1506)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1506.md
+# dotnet_diagnostic.SA1506.severity = default
+
+# CodeMustNotContainMultipleBlankLinesInARow (SA1507)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md
+# dotnet_diagnostic.SA1507.severity = default
+
+# ClosingBracesMustNotBePrecededByBlankLine (SA1508)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md
+# dotnet_diagnostic.SA1508.severity = default
+
+# OpeningBracesMustNotBePrecededByBlankLine (SA1509)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md
+# dotnet_diagnostic.SA1509.severity = default
+
+# ChainedStatementBlocksMustNotBePrecededByBlankLine (SA1510)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1510.md
+# dotnet_diagnostic.SA1510.severity = default
+
+# WhileDoFooterMustNotBePrecededByBlankLine (SA1511)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1511.md
+# dotnet_diagnostic.SA1511.severity = default
+
+# SingleLineCommentsMustNotBeFollowedByBlankLine (SA1512)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1512.md
+# dotnet_diagnostic.SA1512.severity = default
+
+# ClosingBraceMustBeFollowedByBlankLine (SA1513)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1513.md
+# dotnet_diagnostic.SA1513.severity = default
+
+# ElementDocumentationHeaderMustBePrecededByBlankLine (SA1514)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1514.md
+# dotnet_diagnostic.SA1514.severity = default
+
+# SingleLineCommentMustBePrecededByBlankLine (SA1515)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
+# dotnet_diagnostic.SA1515.severity = default
+
+# ElementsMustBeSeparatedByBlankLine (SA1516)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md
+# dotnet_diagnostic.SA1516.severity = default
+
+# CodeMustNotContainBlankLinesAtStartOfFile (SA1517)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1517.md
+# dotnet_diagnostic.SA1517.severity = default
+
+# UseLineEndingsCorrectlyAtEndOfFile (SA1518)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
+# dotnet_diagnostic.SA1518.severity = default
+
+# BracesMustNotBeOmittedFromMultiLineChildStatement (SA1519)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md
+# dotnet_diagnostic.SA1519.severity = default
+
+# UseBracesConsistently (SA1520)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md
+# dotnet_diagnostic.SA1520.severity = default
+
+##########################################
+# StyleCop Analyzers
+# Documentation Rules (SA1600-)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/LayoutRules.md
+##########################################
+[*.{cs,csx,cake}]
+
+# ElementsMustBeDocumented (SA1600)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
+# dotnet_diagnostic.SA1600.severity = default
+
+# PartialElementsMustBeDocumented (SA1601)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1601.md
+# dotnet_diagnostic.SA1601.severity = default
+
+# EnumerationItemsMustBeDocumented (SA1602)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
+# dotnet_diagnostic.SA1602.severity = default
+
+# DocumentationMustContainValidXml (SA1603)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1603.md
+# dotnet_diagnostic.SA1603.severity = default
+
+# ElementDocumentationMustHaveSummary (SA1604)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
+# dotnet_diagnostic.SA1604.severity = default
+
+# PartialElementDocumentationMustHaveSummary (SA1605)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1605.md
+# dotnet_diagnostic.SA1605.severity = default
+
+# ElementDocumentationMustHaveSummaryText (SA1606)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1606.md
+# dotnet_diagnostic.SA1606.severity = default
+
+# PartialElementDocumentationMustHaveSummaryText (SA1607)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1607.md
+# dotnet_diagnostic.SA1607.severity = default
+
+# ElementDocumentationMustNotHaveDefaultSummary (SA1608)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1608.md
+# dotnet_diagnostic.SA1608.severity = default
+
+# PropertyDocumentationMustHaveValue (SA1609)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1609.md
+# dotnet_diagnostic.SA1609.severity = default
+
+# PropertyDocumentationMustHaveValueText (SA1610)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1610.md
+# dotnet_diagnostic.SA1610.severity = default
+
+# ElementParametersMustBeDocumented (SA1611)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+# dotnet_diagnostic.SA1611.severity = default
+
+# ElementParameterDocumentationMustMatchElementParameters (SA1612)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1612.md
+# dotnet_diagnostic.SA1612.severity = default
+
+# ElementParameterDocumentationMustDeclareParameterName (SA1613)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1613.md
+# dotnet_diagnostic.SA1613.severity = default
+
+# ElementParameterDocumentationMustHaveText (SA1614)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
+# dotnet_diagnostic.SA1614.severity = default
+
+# ElementReturnValueMustBeDocumented (SA1615)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
+# dotnet_diagnostic.SA1615.severity = default
+
+# ElementReturnValueDocumentationMustHaveText (SA1616)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
+# dotnet_diagnostic.SA1616.severity = default
+
+# VoidReturnValueMustNotBeDocumented (SA1617)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
+# dotnet_diagnostic.SA1617.severity = default
+
+# GenericTypeParametersMustBeDocumented (SA1618)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1618.md
+# dotnet_diagnostic.SA1618.severity = default
+
+# GenericTypeParametersMustBeDocumentedPartialClass (SA1619)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1619.md
+# dotnet_diagnostic.SA1619.severity = default
+
+# GenericTypeParameterDocumentationMustMatchTypeParameters (SA1620)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md
+# dotnet_diagnostic.SA1620.severity = default
+
+# GenericTypeParameterDocumentationMustDeclareParameterName (SA1621)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1621.md
+# dotnet_diagnostic.SA1621.severity = default
+
+# GenericTypeParameterDocumentationMustHaveText (SA1622)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md
+# dotnet_diagnostic.SA1622.severity = default
+
+# PropertySummaryDocumentationMustMatchAccessors (SA1623)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
+# dotnet_diagnostic.SA1623.severity = default
+
+# PropertySummaryDocumentationMustOmitSetAccessorWithRestrictedAccess (SA1624)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1624.md
+# dotnet_diagnostic.SA1624.severity = default
+
+# ElementDocumentationMustNotBeCopiedAndPasted (SA1625)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
+# dotnet_diagnostic.SA1625.severity = default
+
+# SingleLineCommentsMustNotUseDocumentationStyleSlashes (SA1626)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
+# dotnet_diagnostic.SA1626.severity = default
+
+# DocumentationTextMustNotBeEmpty (SA1627)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
+# dotnet_diagnostic.SA1627.severity = default
+
+# DocumentationTextMustBeginWithACapitalLetter (SA1628)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md
+# dotnet_diagnostic.SA1628.severity = default
+
+# DocumentationTextMustEndWithAPeriod (SA1629)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
+# dotnet_diagnostic.SA1629.severity = default
+
+# DocumentationTextMustContainWhitespace (SA1630)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1630.md
+# dotnet_diagnostic.SA1630.severity = default
+
+# DocumentationMustMeetCharacterPercentage (SA1631)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1631.md
+# dotnet_diagnostic.SA1631.severity = default
+
+# DocumentationTextMustMeetMinimumCharacterLength (SA1632)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1632.md
+# dotnet_diagnostic.SA1632.severity = default
+
+# FileMustHaveHeader (SA1633)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
 dotnet_diagnostic.SA1633.severity = none
 
-# SA1413: The last statement in a multi-line C# initializer or list is missing a trailing comma
-dotnet_diagnostic.SA1413.severity = warning
+# FileHeaderMustShowCopyright (SA1634)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md
+# dotnet_diagnostic.SA1634.severity = default
+
+# FileHeaderMustHaveCopyrightText (SA1635)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md
+# dotnet_diagnostic.SA1635.severity = default
+
+# FileHeaderCopyrightTextMustMatch (SA1636)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md
+dotnet_diagnostic.SA1636.severity = none
+
+# FileHeaderMustContainFileName (SA1637)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md
+# dotnet_diagnostic.SA1637.severity = default
+
+# FileHeaderFileNameDocumentationMustMatchFileName (SA1638)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md
+# dotnet_diagnostic.SA1638.severity = default
+
+# FileHeaderMustHaveSummary (SA1639)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md
+# dotnet_diagnostic.SA1639.severity = default
+
+# FileHeaderMustHaveValidCompanyText (SA1640)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md
+# dotnet_diagnostic.SA1640.severity = default
+
+# FileHeaderCompanyNameTextMustMatch (SA1641)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md
+# dotnet_diagnostic.SA1641.severity = default
+
+# ConstructorSummaryDocumentationMustBeginWithStandardText (SA1642)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
+# dotnet_diagnostic.SA1642.severity = default
+
+# DestructorSummaryDocumentationMustBeginWithStandardText (SA1643)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1643.md
+# dotnet_diagnostic.SA1643.severity = default
+
+# DocumentationHeadersMustNotContainBlankLines (SA1644)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md
+# dotnet_diagnostic.SA1644.severity = default
+
+# IncludedDocumentationFileDoesNotExist (SA1645)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1645.md
+# dotnet_diagnostic.SA1645.severity = default
+
+# IncludedDocumentationXPathDoesNotExist (SA1646)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1646.md
+# dotnet_diagnostic.SA1646.severity = default
+
+# IncludeNodeDoesNotContainValidFileAndPath (SA1647)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1647.md
+# dotnet_diagnostic.SA1647.severity = default
+
+# InheritDocMustBeUsedWithInheritingClass (SA1648)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
+# dotnet_diagnostic.SA1648.severity = default
+
+# FileNameMustMatchTypeName (SA1649)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1649.md
+# dotnet_diagnostic.SA1649.severity = default
+
+# ElementDocumentationMustBeSpelledCorrectly (SA1650)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1650.md
+# dotnet_diagnostic.SA1650.severity = default
+
+# DoNotUsePlaceholderElements (SA1651)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1651.md
+# dotnet_diagnostic.SA1651.severity = default
+
+# EnableXmlDocumentationOutput (SA1652)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1652.md
+# dotnet_diagnostic.SA1652.severity = default
 
 ##########################################
-# code analysis rules
+# StyleCop Analyzers
+# Alternative Rules (SX0000-)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/AlternativeRules.md
 ##########################################
+[*.{cs,csx,cake}]
 
-[*.{cs,vb}]
-# CA1003: Use generic event handler instances
-dotnet_diagnostic.CA1003.severity = warning
-dotnet_code_quality.CA1003.api_surface = all
-# CA1036: Override methods on comparable types
-dotnet_diagnostic.CA1036.severity = warning
-# CA1050: Declare types in namespaces
-dotnet_diagnostic.CA1050.severity = warning
-# CA1052: Static holder types should be Static or NotInheritable
-dotnet_diagnostic.CA1052.severity = warning
-dotnet_code_quality.CA1052.api_surface = all
-# CA1058: Types should not extend certain base types
-dotnet_diagnostic.CA1058.severity = warning
-# CA1065: Do not raise exceptions in unexpected locations
-dotnet_diagnostic.CA1065.severity = warning
-# CA1067: Override Equals when implementing IEquatable
-dotnet_diagnostic.CA1067.severity = warning
-# CA1304: Specify CultureInfo
-dotnet_diagnostic.CA1304.severity = warning
-# CA1305: Specify IFormatProvider
-dotnet_diagnostic.CA1305.severity = warning
-# CA1307: Specify StringComparison for clarity
-dotnet_diagnostic.CA1307.severity = warning
-# CA1309: Use ordinal StringComparison
-dotnet_diagnostic.CA1309.severity = warning
-# CA1310: Specify StringComparison for correctness
-dotnet_diagnostic.CA1310.severity = warning
-# CA1710: Identifiers should have correct suffix
-dotnet_diagnostic.CA1710.severity = warning
-dotnet_code_quality.CA1710.api_surface = all
-# CA1724: Type names should not match namespaces
-dotnet_diagnostic.CA1724.severity = warning
-# CA1815: Override equals and operator equals on value types
-dotnet_diagnostic.CA1815.severity = warning
-# CA1825: Avoid zero-length array allocations
-dotnet_diagnostic.CA1825.severity = warning
-# CA1829: Use Length/Count property instead of Enumerable.Count method
-dotnet_diagnostic.CA1829.severity = warning
-# CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
-dotnet_diagnostic.CA1830.severity = warning
-# CA1834: Use StringBuilder.Append(char) for single character strings
-dotnet_diagnostic.CA1834.severity = warning
-# CA2201: Do not raise reserved exception types
-dotnet_diagnostic.CA2201.severity = warning
-# CA2208: Instantiate argument exceptions correctly
-dotnet_diagnostic.CA2208.severity = warning
-# CA2211: Non-constant fields should not be visible
-dotnet_diagnostic.CA2211.severity = warning
-# CA2214: Do not call overridable methods in constructors
-dotnet_diagnostic.CA2214.severity = warning
-# CA2217: Do not mark enums with FlagsAttribute
-dotnet_diagnostic.CA2217.severity = warning
-# CA2219: Do not raise exceptions in exception clauses
-dotnet_diagnostic.CA2219.severity = warning
-# CA2242: Test for NaN correctly
-dotnet_diagnostic.CA2242.severity = warning
-# CA5359: Do not disable certificate validation
-dotnet_diagnostic.CA5359.severity = warning
+# DoNotPrefixLocalMembersWithThis (SX1101)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1101.md
+dotnet_diagnostic.SX1101.severity = none
+
+# FieldNamesMustBeginWithUnderscore (SX1309)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309.md
+dotnet_diagnostic.SX1309.severity = none
+
+# StaticFieldNamesMustBeginWithUnderscore (SX1309S)
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1309S.md
+dotnet_diagnostic.SX1309S.severity = none
 
 ##########################################
-# StyleCop rules
+# IDisposable Analyzers
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers
 ##########################################
+[*.{cs,csx,cake}]
 
-[*.{cs}]
-# MA0001: StringComparison is missing (same as CA1307 & CA1309 & CA1310)
+# Dispose created (IDISP001)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP001.md
+# dotnet_diagnostic.IDISP001.severity = default
+
+# Dispose member (IDISP002)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP002.md
+# dotnet_diagnostic.IDISP002.severity = default
+
+# Dispose previous before re-assigning (IDISP003)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP0003.md
+# dotnet_diagnostic.IDISP003.severity = default
+
+# Don't ignore created IDisposable (IDISP004)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP0004.md
+# dotnet_diagnostic.IDISP004.severity = default
+
+# Return type should indicate that the value should be disposed (IDISP005)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP0005.md
+# dotnet_diagnostic.IDISP005.severity = default
+
+# Implement IDisposable (IDISP006)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP006.md
+# dotnet_diagnostic.IDISP006.severity = default
+
+# Don't dispose injected (IDISP007)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP007.md
+# dotnet_diagnostic.IDISP007.severity = default
+
+# Don't assign member with injected and created disposables (IDISP008)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP008.md
+# dotnet_diagnostic.IDISP008.severity = default
+
+# Add IDisposable interface (IDISP009)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP009.md
+# dotnet_diagnostic.IDISP009.severity = default
+
+# Call base.Dispose(disposing) (IDISP010)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP010.md
+# dotnet_diagnostic.IDISP010.severity = default
+
+# Don't return disposed instance (IDISP011)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP011.md
+# dotnet_diagnostic.IDISP011.severity = default
+
+# Property should not return created disposable (IDISP012)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP012.md
+# dotnet_diagnostic.IDISP012.severity = default
+
+# Await in using (IDISP013)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP013.md
+# dotnet_diagnostic.IDISP013.severity = default
+
+# Use a single instance of HttpClient (IDISP014)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP014.md
+# dotnet_diagnostic.IDISP014.severity = default
+
+# Member should not return created and cached instance (IDISP015)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP015.md
+# dotnet_diagnostic.IDISP015.severity = default
+
+# Don't use disposed instance (IDISP016)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP016.md
+# dotnet_diagnostic.IDISP016.severity = default
+
+# Prefer using (IDISP017)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP017.md
+# dotnet_diagnostic.IDISP017.severity = default
+
+# Call SuppressFinalize (IDISP018)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP018.md
+# dotnet_diagnostic.IDISP018.severity = default
+
+# Call SuppressFinalize (IDISP019)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP019.md
+# dotnet_diagnostic.IDISP019.severity = default
+
+# Call SuppressFinalize(this) (IDISP020)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP020.md
+# dotnet_diagnostic.IDISP020.severity = default
+
+# Call this.Dispose(true) (IDISP021)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP021.md
+# dotnet_diagnostic.IDISP021.severity = default
+
+# Call this.Dispose(false) (IDISP022)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP022.md
+# dotnet_diagnostic.IDISP022.severity = default
+
+# Don't use reference types in finalizer context (IDISP023)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP023.md
+# dotnet_diagnostic.IDISP023.severity = default
+
+# Don't call GC.SuppressFinalize(this) when the type is sealed and has no finalizer (IDISP024)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP024.md
+# dotnet_diagnostic.IDISP024.severity = default
+
+# Class with no virtual dispose method should be sealed (IDISP025)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP025.md
+# dotnet_diagnostic.IDISP025.severity = default
+
+# Class with no virtual DisposeAsyncCore method should be sealed (IDISP026)
+# https://github.com/DotNetAnalyzers/IDisposableAnalyzers/blob/master/documentation/IDISP026.md
+# dotnet_diagnostic.IDISP026.severity = default
+
+##########################################
+# Meziantou Analyzer
+# https://github.com/meziantou/Meziantou.Analyzer
+##########################################
+[*.{cs,csx,cake}]
+
+# StringComparison is missing (MA0001)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0001.md
+# Same as CA1307, CA1309, CA1310
 dotnet_diagnostic.MA0001.severity = none
-# MA0002: IEqualityComparer<string> or IComparer<string> is missing
-dotnet_diagnostic.MA0002.severity = warning
-# MA0003: Add parameter name to improve readability
-dotnet_diagnostic.MA0003.severity = suggestion
-# MA0004: Use Task.ConfigureAwait (same as CA2007)
-dotnet_diagnostic.MA0004.severity = warning
-# MA0005: Use Array.Empty<T>() (same as CA1825)
+
+# IEqualityComparer<string> or IComparer<string> is missing (MA0002)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0002.md
+# dotnet_diagnostic.MA0002.severity = default
+
+# Add parameter name to improve readability (MA0003)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0003.md
+# dotnet_diagnostic.MA0003.severity = default
+
+# Use Task.ConfigureAwait (MA0004)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0004.md
+# dotnet_diagnostic.MA0004.severity = default
+
+# Use Array.Empty<T>() (MA0005)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0005.md
+# Same as CA1825
 dotnet_diagnostic.MA0005.severity = none
-# MA0006: Use String.Equals instead of equality operator
-dotnet_diagnostic.MA0006.severity = warning
-# MA0007: Add a comma after the last value (same as SA1413)
+
+# Use String.Equals instead of equality operator (MA0006)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0006.md
+# dotnet_diagnostic.MA0006.severity = default
+
+# Add a comma after the last value (MA0007)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0007.md
+# Same as SA1413
 dotnet_diagnostic.MA0007.severity = none
-# MA0008: Add StructLayoutAttribute
-dotnet_diagnostic.MA0008.severity = warning
-# MA0009: Add regex evaluation timeout
-dotnet_diagnostic.MA0009.severity = warning
 
-# MA0010: Mark attributes with AttributeUsageAttribute
-dotnet_diagnostic.MA0010.severity = warning
-# MA0011: IFormatProvider is missing (same as CA1304 & CA1305)
+# Add StructLayoutAttribute (MA0008)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0008.md
+# dotnet_diagnostic.MA0008.severity = default
+
+# Add regex evaluation timeout (MA0009)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0009.md
+# dotnet_diagnostic.MA0009.severity = default
+
+# Mark attributes with AttributeUsageAttribute (MA0010)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0010.md
+# Same as CA1018
+dotnet_diagnostic.MA0010.severity = none
+
+# IFormatProvider is missing (MA0011)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0011.md
+# Same as CA1304, 1305
 dotnet_diagnostic.MA0011.severity = none
-# MA0012: Do not raise reserved exception type (same as CA2201)
+
+# Do not raise reserved exception type (MA0012)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0012.md
+# Same as CA2201
 dotnet_diagnostic.MA0012.severity = none
-# MA0013: Types should not extend System.ApplicationException (same as CA1058)
+
+# Types should not extend System.ApplicationException (MA0013)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0013.md
+# Same as CA1058
 dotnet_diagnostic.MA0013.severity = none
-# MA0014: Do not raise System.ApplicationException type (same as CA2201)
+
+# Do not raise System.ApplicationException type (MA0014)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0014.md
+# Same as CA2201
 dotnet_diagnostic.MA0014.severity = none
-# MA0015: Specify the parameter name in ArgumentException (same as CA2208)
-dotnet_diagnostic.MA0015.severity = none          
-# MA0016: Prefer using collection abstraction instead of implementation
-dotnet_diagnostic.MA0016.severity = warning
-# MA0017: Abstract types should not have public or internal constructors
-dotnet_diagnostic.MA0017.severity = warning
-# MA0018: Do not declare static members on generic types (deprecated; use CA1000 instead)
+
+# Specify the parameter name in ArgumentException (MA0015)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0015.md
+# Same as CA2208
+dotnet_diagnostic.MA0015.severity = none
+
+# Prefer using collection abstraction instead of implementation (MA0016)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0016.md
+# dotnet_diagnostic.MA0016.severity = default
+
+# Abstract types should not have public or internal constructors (MA0017)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0017.md
+# Same as S3442
+# dotnet_diagnostic.MA0017.severity = default
+
+# Do not declare static members on generic types (deprecated; use CA1000 instead) (MA0018)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0018.md
 dotnet_diagnostic.MA0018.severity = none
-# MA0019: Use EventArgs.Empty
-dotnet_diagnostic.MA0019.severity = warning
 
-# MA0020: Use direct methods instead of LINQ methods (same as CA1829)
+# Use EventArgs.Empty (MA0019)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0019.md
+# dotnet_diagnostic.MA0019.severity = default
+
+# Use direct methods instead of LINQ methods (MA0020)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0020.md
+# Same as CA1826
 dotnet_diagnostic.MA0020.severity = none
-# MA0021: Use StringComparer.GetHashCode instead of string.GetHashCode
-dotnet_diagnostic.MA0021.severity = warning
-# MA0022: Return Task.FromResult instead of returning null
-dotnet_diagnostic.MA0022.severity = warning
-# MA0023: Add RegexOptions.ExplicitCapture
-dotnet_diagnostic.MA0023.severity = warning
-# MA0024: Use an explicit StringComparer when possible
-dotnet_diagnostic.MA0024.severity = warning
-# MA0025: Implement the functionality instead of throwing NotImplementedException
-dotnet_diagnostic.MA0025.severity = warning
-# MA0026: Fix TODO comment
-dotnet_diagnostic.MA0026.severity = warning
-# MA0027: Prefer rethrowing an exception implicitly (same as CA2200)
-dotnet_diagnostic.MA0027.severity = none
-# MA0028: Optimize StringBuilder usage (same as CA1830 & CA1834)
-dotnet_diagnostic.MA0028.severity = none
-# MA0029: Combine LINQ methods
-dotnet_diagnostic.MA0029.severity = suggestion
 
-# MA0030: Remove useless OrderBy call
-dotnet_diagnostic.MA0030.severity = warning
-# MA0031: Optimize Enumerable.Count() usage
-dotnet_diagnostic.MA0031.severity = suggestion
-# MA0032: Use an overload with a CancellationToken argument
-dotnet_diagnostic.MA0032.severity = none
-# MA0033: Do not tag instance fields with ThreadStaticAttribute
-dotnet_diagnostic.MA0033.severity = warning
-# MA0034:
-dotnet_diagnostic.MA0034.severity = none
-# MA0035: Do not use dangerous threading methods
-dotnet_diagnostic.MA0035.severity = warning
-# MA0036: Make class static (same as CA1052)
-dotnet_diagnostic.MA0036.severity = none
-# MA0037: Remove empty statement
-dotnet_diagnostic.MA0037.severity = error
-# MA0038: Make method static (deprecated, use CA1822 instead)
+# Use StringComparer.GetHashCode instead of string.GetHashCode (MA0021)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0021.md
+# dotnet_diagnostic.MA0021.severity = default
+
+# Return Task.FromResult instead of returning null (MA0022)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0022.md
+# dotnet_diagnostic.MA0022.severity = default
+
+# Add RegexOptions.ExplicitCapture (MA0023)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0023.md
+# dotnet_diagnostic.MA0023.severity = default
+
+# Use an explicit StringComparer when possible (MA0024)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0024.md
+# dotnet_diagnostic.MA0024.severity = default
+
+# Implement the functionality instead of throwing NotImplementedException (MA0025)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0025.md
+# dotnet_diagnostic.MA0025.severity = default
+
+# Fix TODO comment (MA0026)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md
+# dotnet_diagnostic.MA0026.severity = default
+
+# Prefer rethrowing an exception implicitly (MA0027)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0027.md
+# Same as CA2200
+dotnet_diagnostic.MA0027.severity = none
+
+# Optimize StringBuilder usage (MA0028)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0028.md
+# Same as CA1830, CA1834
+dotnet_diagnostic.MA0028.severity = none
+
+# Combine LINQ methods (MA0029)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0029.md
+# dotnet_diagnostic.MA0029.severity = default
+
+# Remove useless OrderBy call (MA0030)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0030.md
+# dotnet_diagnostic.MA0030.severity = default
+
+# Optimize Enumerable.Count() usage (MA0031)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0031.md
+# dotnet_diagnostic.MA0031.severity = default
+
+# Use an overload with a CancellationToken argument (MA0032)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0032.md
+# dotnet_diagnostic.MA0032.severity = default
+
+# Do not tag instance fields with ThreadStaticAttribute (MA0033)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0033.md
+# dotnet_diagnostic.MA0033.severity = default
+
+# Do not use dangerous threading methods (MA0035)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0035.md
+# dotnet_diagnostic.MA0035.severity = default
+
+# Make class static (MA0036)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0036.md
+# dotnet_diagnostic.MA0036.severity = default
+
+# Remove empty statement (MA0037)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0037.md
+# dotnet_diagnostic.MA0037.severity = default
+
+# Make method static (deprecated, use CA1822 instead) (MA0038)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0038.md
 dotnet_diagnostic.MA0038.severity = none
-# MA0039: Do not write your own certificate validation method (same as CA5359)
+
+# Do not write your own certificate validation method (MA0039)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0039.md
+# Same as CA5359
 dotnet_diagnostic.MA0039.severity = none
 
-# MA0040: Forward the CancellationToken parameter to methods that take one
-dotnet_diagnostic.MA0040.severity = suggestion
-# MA0041: Make property static (deprecated, use CA1822 instead)
+# Forward the CancellationToken parameter to methods that take one (MA0040)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0040.md
+# dotnet_diagnostic.MA0040.severity = default
+
+# Make property static (deprecated, use CA1822 instead) (MA0041)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0041.md
 dotnet_diagnostic.MA0041.severity = none
-# MA0042: Do not use blocking calls in an async method
-dotnet_diagnostic.MA0042.severity = suggestion
-# MA0043: Use nameof operator in ArgumentException
-dotnet_diagnostic.MA0043.severity = suggestion
-# MA0044: Remove useless ToString call
-dotnet_diagnostic.MA0044.severity = suggestion
-# MA0045: Do not use blocking calls in a sync method (need to make calling method async)
-dotnet_diagnostic.MA0045.severity = none
-# MA0046: Use EventHandler<T> to declare events (same as CA1003)
-dotnet_diagnostic.MA0046.severity = none
-# MA0047: Declare types in namespaces (same as CA1050)
+
+# Do not use blocking calls in an async method (MA0042)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0042.md
+# dotnet_diagnostic.MA0042.severity = default
+
+# Use nameof operator in ArgumentException (MA0043)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0043.md
+# dotnet_diagnostic.MA0043.severity = default
+
+# Remove useless ToString call (MA0044)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0044.md
+# dotnet_diagnostic.MA0044.severity = default
+
+# Do not use blocking calls in a sync method (need to make calling method async) (MA0045)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0045.md
+# dotnet_diagnostic.MA0045.severity = default
+
+# Use EventHandler<T> to declare events (MA0046)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0046.md
+# dotnet_diagnostic.MA0046.severity = default
+
+# Declare types in namespaces (MA0047)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0047.md
+# Same as CA1050, S3903
 dotnet_diagnostic.MA0047.severity = none
-# MA0048: File name must match type name (same as SA1649)
+
+# File name must match type name (MA0048)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md
+# Same as SA1649
 dotnet_diagnostic.MA0048.severity = none
-# MA0049: Type name should not match containing namespace (same as CA1724)
+
+# Type name should not match containing namespace (MA0049)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0049.md
+# Same as CA1724
 dotnet_diagnostic.MA0049.severity = none
 
-# MA0050: Validate arguments correctly in iterator methods
-dotnet_diagnostic.MA0050.severity = suggestion
-# MA0051: Method is too long
-dotnet_diagnostic.MA0051.severity = warning
-# MA0052: Replace constant Enum.ToString with nameof
-dotnet_diagnostic.MA0052.severity = suggestion
-# MA0053: Make class sealed
-dotnet_diagnostic.MA0053.severity = suggestion
-# MA0054: Embed the caught exception as innerException
-dotnet_diagnostic.MA0054.severity = warning
-# MA0055: Do not use finalizer
-dotnet_diagnostic.MA0055.severity = warning
-# MA0056: Do not call overridable members in constructor (same as CA2214)
+# Validate arguments correctly in iterator methods (MA0050)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0050.md
+# dotnet_diagnostic.MA0050.severity = default
+
+# Method is too long (MA0051)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0051.md
+# dotnet_diagnostic.MA0051.severity = default
+
+# Replace constant Enum.ToString with nameof (MA0052)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0052.md
+# dotnet_diagnostic.MA0052.severity = default
+
+# Make class sealed (MA0053)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0053.md
+# dotnet_diagnostic.MA0053.severity = default
+
+# Embed the caught exception as innerException (MA0054)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0054.md
+# dotnet_diagnostic.MA0054.severity = default
+
+# Do not use finalizers (MA0055)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0055.md
+# dotnet_diagnostic.MA0055.severity = default
+
+# Do not call overridable members in constructor (MA0056)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0056.md
+# Same as CA2214
 dotnet_diagnostic.MA0056.severity = none
-# MA0057: Class name should end with 'Attribute' (same as CA1710)
+
+# Class name should end with 'Attribute' (MA0057)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0057.md
+# Same as CA1710
 dotnet_diagnostic.MA0057.severity = none
-# MA0058: Class name should end with 'Exception' (same as CA1710)
+
+# Class name should end with 'Exception' (MA0058)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0058.md
+# Same as CA1710
 dotnet_diagnostic.MA0058.severity = none
-# MA0059: Class name should end with 'EventArgs' (same as CA1710)
+
+# Class name should end with 'EventArgs' (MA0059)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0059.md
+# Same as CA1710
 dotnet_diagnostic.MA0059.severity = none
 
-# MA0060: The value returned by Stream.Read/Stream.ReadAsync is not used
-dotnet_diagnostic.MA0060.severity = warning
-# MA0061: Method overrides should not change default values
-dotnet_diagnostic.MA0061.severity = warning
-# MA0062: Non-flags enums should not be marked with "FlagsAttribute" (same as CA2217)
+# The value returned by Stream.Read/Stream.ReadAsync is not used (MA0060)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0060.md
+# dotnet_diagnostic.MA0060.severity = default
+
+# Method overrides should not change default values (MA0061)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0061.md
+# dotnet_diagnostic.MA0061.severity = default
+
+# Non-flags enums should not be marked with "FlagsAttribute" (MA0062)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0062.md
+# Same as CA2217
 dotnet_diagnostic.MA0062.severity = none
-# MA0063: Use Where before OrderBy
-dotnet_diagnostic.MA0063.severity = suggestion
-# MA0064: Avoid locking on publicly accessible instance
-dotnet_diagnostic.MA0064.severity = warning
-# MA0065: Default ValueType.Equals or HashCode is used for struct equality (same as CA1815)
-dotnet_diagnostic.MA0065.severity = none
-# MA0066: Hash table unfriendly type is used in a hash table (same as CA1815)
-dotnet_diagnostic.MA0066.severity = none
-# MA0067: Use Guid.Empty
-dotnet_diagnostic.MA0067.severity = suggestion
-# MA0068: Invalid parameter name for nullable attribute
-dotnet_diagnostic.MA0068.severity = warning
-# MA0069: Non-constant static fields should not be visible (same as CA2211)
+
+# Use Where before OrderBy (MA0063)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0063.md
+# dotnet_diagnostic.MA0063.severity = default
+
+# Avoid locking on publicly accessible instance (MA0064)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0064.md
+# dotnet_diagnostic.MA0064.severity = default
+
+# Default ValueType.Equals or HashCode is used for struct equality (MA0065)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0065.md
+# dotnet_diagnostic.MA0065.severity = default
+
+# Hash table unfriendly type is used in a hash table (MA0066)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0066.md
+# dotnet_diagnostic.MA0066.severity = default
+
+# Use Guid.Empty (MA0067)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0067.md
+# dotnet_diagnostic.MA0067.severity = default
+
+# Invalid parameter name for nullable attribute (MA0068)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0068.md
+# dotnet_diagnostic.MA0068.severity = default
+
+# Non-constant static fields should not be visible (MA0069)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0069.md
+# Same as CA2211
 dotnet_diagnostic.MA0069.severity = none
 
-# MA0070: Obsolete attributes should include explanations
-dotnet_diagnostic.MA0070.severity = warning
-# MA0071: Avoid using redundant else
-dotnet_diagnostic.MA0071.severity = suggestion
-# MA0072: Do not throw from a finally block (same as CA1065 & CA2219)
+# Obsolete attributes should include explanations (MA0070)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0070.md
+# dotnet_diagnostic.MA0070.severity = default
+
+# Avoid using redundant else (MA0071)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0071.md
+# dotnet_diagnostic.MA0071.severity = default
+
+# Do not throw from a finally block (MA0072)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0072.md
+# Same as CA1065, CA2219,
 dotnet_diagnostic.MA0072.severity = none
-# MA0073: Avoid comparison with bool constant
-dotnet_diagnostic.MA0073.severity = suggestion
-# MA0074: Avoid implicit culture-sensitive methods (same as CA1307 & CA1309)
+
+# Avoid comparison with bool constant (MA0073)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0073.md
+# dotnet_diagnostic.MA0073.severity = default
+
+# Avoid implicit culture-sensitive methods (MA0074)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0074.md
+# Same as CA1307, CA1309
 dotnet_diagnostic.MA0074.severity = none
-# MA0075: Do not use implicit culture-sensitive ToString
-dotnet_diagnostic.MA0075.severity = suggestion
-# MA0076: Do not use implicit culture-sensitive ToString in interpolated strings
-dotnet_diagnostic.MA0076.severity = suggestion
-# MA0077: A class that provides Equals(T) should implement IEquatable<T>
-dotnet_diagnostic.MA0077.severity = warning
-# MA0078: Use 'Cast' instead of 'Select' to cast
-dotnet_diagnostic.MA0078.severity = suggestion
-# MA0079: Forward the CancellationToken using .WithCancellation()
-dotnet_diagnostic.MA0079.severity = suggestion
 
-# MA0080: Use a cancellation token using .WithCancellation()
-dotnet_diagnostic.MA0080.severity = none
-# MA0081: Method overrides should not omit params keyword
-dotnet_diagnostic.MA0081.severity = warning
-# MA0082: NaN should not be used in comparisons (same as CA2242)
+# Do not use implicit culture-sensitive ToString (MA0075)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0075.md
+# dotnet_diagnostic.MA0075.severity = default
+
+# Do not use implicit culture-sensitive ToString in interpolated strings (MA0076)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0076.md
+# dotnet_diagnostic.MA0076.severity = default
+
+# A class that provides Equals(T) should implement IEquatable<T> (MA0077)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0077.md
+# dotnet_diagnostic.MA0077.severity = default
+
+# Use 'Cast' instead of 'Select' to cast (MA0078)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0078.md
+# dotnet_diagnostic.MA0078.severity = default
+
+# Forward the CancellationToken using .WithCancellation() (MA0079)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0079.md
+# dotnet_diagnostic.MA0079.severity = default
+
+# Use a cancellation token using .WithCancellation() (MA0080)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0080.md
+# dotnet_diagnostic.MA0080.severity = default
+
+# Method overrides should not omit params keyword (MA0081)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0081.md
+# dotnet_diagnostic.MA0081.severity = default
+
+# NaN should not be used in comparisons (MA0082)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0082.md
+# Same as CA2242
 dotnet_diagnostic.MA0082.severity = none
-# MA0083: ConstructorArgument parameters should exist in constructors
-dotnet_diagnostic.MA0083.severity = warning
-# MA0084: Local variables should not hide other symbols
-dotnet_diagnostic.MA0084.severity = warning
-# MA0085: Anonymous delegates should not be used to unsubscribe from Events
-dotnet_diagnostic.MA0085.severity = warning
-# MA0086: Do not throw from a finalizer (same as CA1065)
+
+# ConstructorArgument parameters should exist in constructors (MA0083)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0083.md
+# dotnet_diagnostic.MA0083.severity = default
+
+# Local variables should not hide other symbols (MA0084)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0084.md
+# dotnet_diagnostic.MA0084.severity = default
+
+# Anonymous delegates should not be used to unsubscribe from Events (MA0085)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0085.md
+# dotnet_diagnostic.MA0085.severity = default
+
+# Do not throw from a finalizer (MA0086)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0086.md
+# Same as CA1065
 dotnet_diagnostic.MA0086.severity = none
-# MA0087: Parameters with [DefaultParameterValue] attributes should also be marked [Optional]
-dotnet_diagnostic.MA0087.severity = warning
-# MA0088: Use [DefaultParameterValue] instead of [DefaultValue]
-dotnet_diagnostic.MA0088.severity = warning
-# MA0089: Optimize string method usage
-dotnet_diagnostic.MA0089.severity = suggestion
 
-# MA0090: Remove empty else/finally block
-dotnet_diagnostic.MA0090.severity = suggestion
-# MA0091: Sender should be 'this' for instance events
-dotnet_diagnostic.MA0091.severity = warning
-# MA0092: Sender should be 'null' for static events
-dotnet_diagnostic.MA0092.severity = warning
-# MA0093: EventArgs should not be null
-dotnet_diagnostic.MA0093.severity = warning
-# MA0094: A class that provides CompareTo(T) should implement IComparable<T>
-dotnet_diagnostic.MA0094.severity = warning
-# MA0095: A class that implements IEquatable<T> should override Equals(object) (same as CA1067)
+# Parameters with [DefaultParameterValue] attributes should also be marked [Optional] (MA0087)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0087.md
+# Same as S3450
+# dotnet_diagnostic.MA0087.severity = default
+
+# Use [DefaultParameterValue] instead of [DefaultValue] (MA0088)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0088.md
+# dotnet_diagnostic.MA0088.severity = default
+
+# Optimize string method usage (MA0089)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0089.md
+# dotnet_diagnostic.MA0089.severity = default
+
+# Remove empty else/finally block (MA0090)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0090.md
+# dotnet_diagnostic.MA0090.severity = default
+
+# Sender should be 'this' for instance events (MA0091)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0091.md
+# dotnet_diagnostic.MA0091.severity = default
+
+# Sender should be 'null' for static events (MA0092)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0092.md
+# dotnet_diagnostic.MA0092.severity = default
+
+# EventArgs should not be null (MA0093)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0093.md
+# dotnet_diagnostic.MA0093.severity = default
+
+# A class that provides CompareTo(T) should implement IComparable<T> (MA0094)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0094.md
+# dotnet_diagnostic.MA0094.severity = default
+
+# A class that implements IEquatable<T> should override Equals(object) (MA0095)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0095.md
+# Same as CA1067
 dotnet_diagnostic.MA0095.severity = none
-# MA0096: A class that implements IComparable<T> should also implement IEquatable<T>
-dotnet_diagnostic.MA0096.severity = warning
-# MA0097: A class that implements IComparable<T> or IComparable should override comparison operators (same as CA1036)
+
+# A class that implements IComparable<T> should also implement IEquatable<T> (MA0096)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0096.md
+# dotnet_diagnostic.MA0096.severity = default
+
+# A class that implements IComparable<T> or IComparable should override comparison operators (MA0097)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0097.md
+# Same as CA1036
 dotnet_diagnostic.MA0097.severity = none
-# MA0098: Use indexer instead of LINQ methods
-dotnet_diagnostic.MA0098.severity = suggestion
-# MA0099: Use Explicit enum value instead of 0
-dotnet_diagnostic.MA0099.severity = warning
 
-# MA0100: Await task before disposing of resources
-dotnet_diagnostic.MA0100.severity = warning
-# MA0101: String contains an implicit end of line character
-dotnet_diagnostic.MA0101.severity = silent
-# MA0102: Make member readonly
-dotnet_diagnostic.MA0102.severity = suggestion
-# MA0103: Use SequenceEqual instead of equality operator
-dotnet_diagnostic.MA0103.severity = warning
-# MA0104: Do not create a type with a name from the BCL
-dotnet_diagnostic.MA0104.severity = none
-# MA0105: Use the lambda parameters instead of using a closure
-dotnet_diagnostic.MA0105.severity = suggestion
-# MA0106: Avoid closure by using an overload with the 'factoryArgument' parameter
-dotnet_diagnostic.MA0106.severity = suggestion
-# MA0107: Do not use culture-sensitive object.ToString
-dotnet_diagnostic.MA0107.severity = none
-# MA0108: Remove redundant argument value
-dotnet_diagnostic.MA0108.severity = suggestion
-# MA0109: Consider adding an overload with a Span<T> or Memory<T>
-dotnet_diagnostic.MA0109.severity = none
+# Use indexer instead of LINQ methods (MA0098)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0098.md
+# dotnet_diagnostic.MA0098.severity = default
 
-# MA0110: Use the Regex source generator
-dotnet_diagnostic.MA0110.severity = suggestion
-# MA0111: Use string.Create instead of FormattableString
-dotnet_diagnostic.MA0111.severity = suggestion
-# MA0112: Use 'Count > 0' instead of 'Any()'
-dotnet_diagnostic.MA0112.severity = none
-# MA0113: Use DateTime.UnixEpoch
-dotnet_diagnostic.MA0113.severity = suggestion
-# MA0114: Use DateTimeOffset.UnixEpoch
-dotnet_diagnostic.MA0114.severity = suggestion
-# MA0115: Unknown component parameter
-dotnet_diagnostic.MA0115.severity = warning
-# MA0116: Parameters with [SupplyParameterFromQuery] attributes should also be marked as [Parameter]
-dotnet_diagnostic.MA0116.severity = warning
-# MA0117: Parameters with [EditorRequired] attributes should also be marked as [Parameter]
-dotnet_diagnostic.MA0117.severity = warning
-# MA0118: [JSInvokable] methods must be public
-dotnet_diagnostic.MA0118.severity = warning
-# MA0119: JSRuntime must not be used in OnInitialized or OnInitializedAsync
-dotnet_diagnostic.MA0119.severity = warning
+# Use Explicit enum value instead of 0 (MA0099)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0099.md
+# dotnet_diagnostic.MA0099.severity = default
 
-# MA0120: Use InvokeVoidAsync when the returned value is not used
-dotnet_diagnostic.MA0120.severity = suggestion
-# MA0121: Do not overwrite parameter value
-dotnet_diagnostic.MA0121.severity = none
-# MA0122: Parameters with [SupplyParameterFromQuery] attributes are only valid in routable components (@page)
-dotnet_diagnostic.MA0122.severity = suggestion
-# MA0123: Sequence number must be a constant
-dotnet_diagnostic.MA0123.severity = warning
-# MA0124: Log Parameter type is not valid
-dotnet_diagnostic.MA0124.severity = warning
-# MA0125: The list of log parameter types contains an invalid type
-dotnet_diagnostic.MA0125.severity = warning
-# MA0126: The list of log parameter types contains a duplicate
-dotnet_diagnostic.MA0126.severity = warning
-# MA0127: Use String.Equals instead of is pattern
-dotnet_diagnostic.MA0127.severity = none
-# MA0128: Use 'is' operator instead of SequenceEqual 
-dotnet_diagnostic.MA0128.severity = suggestion
-# MA0129: Await task in using statement
-dotnet_diagnostic.MA0129.severity = warning
+# Await task before disposing of resources (MA0100)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0100.md
+# dotnet_diagnostic.MA0100.severity = default
 
-# MA0130: GetType() should not be used on System.Type instances
-dotnet_diagnostic.MA0130.severity = warning
-# MA0131: ArgumentNullException.ThrowIfNull should not be used with non-nullable types
-dotnet_diagnostic.MA0131.severity = warning
-# MA0132: Do not convert implicitly to DateTimeOffset
-dotnet_diagnostic.MA0132.severity = warning
-# MA0133: Use DateTimeOffset instead of relying on the implicit conversion
-dotnet_diagnostic.MA0133.severity = suggestion
-# MA0134: Observe result of async calls
-dotnet_diagnostic.MA0134.severity = warning
-# MA0135: The log parameter has no configured type
-dotnet_diagnostic.MA0135.severity = none
-# MA0136: Raw String contains an implicit end of line character
+# String contains an implicit end of line character (MA0101)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0101.md
+# dotnet_diagnostic.MA0101.severity = default
+
+# Make member readonly (MA0102)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0102.md
+# dotnet_diagnostic.MA0102.severity = default
+
+# Use SequenceEqual instead of equality operator (MA0103)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0103.md
+# dotnet_diagnostic.MA0103.severity = default
+
+# Do not create a type with a name from the BCL (MA0104)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0104.md
+# dotnet_diagnostic.MA0104.severity = default
+
+# Use the lambda parameters instead of using a closure (MA0105)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0105.md
+# dotnet_diagnostic.MA0105.severity = default
+
+# Avoid closure by using an overload with the 'factoryArgument' parameter (MA0106)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0106.md
+# dotnet_diagnostic.MA0106.severity = default
+
+# Do not use culture-sensitive object.ToString (MA0107)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0107.md
+# dotnet_diagnostic.MA0107.severity = default
+
+# Remove redundant argument value (MA0108)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0108.md
+# dotnet_diagnostic.MA0108.severity = default
+
+# Consider adding an overload with a Span<T> or Memory<T> parameter (MA0109)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0109.md
+# dotnet_diagnostic.MA0109.severity = default
+
+# Use the Regex source generator (MA0110)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0110.md
+# dotnet_diagnostic.MA0110.severity = default
+
+# Use string.Create instead of FormattableString (MA0111)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0111.md
+# dotnet_diagnostic.MA0111.severity = default
+
+# Use 'Count > 0' instead of 'Any()' (MA0112)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0112.md
+# dotnet_diagnostic.MA0112.severity = default
+
+# Use DateTime.UnixEpoch (MA0113)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0113.md
+# dotnet_diagnostic.MA0113.severity = default
+
+# Use DateTimeOffset.UnixEpoch (MA0114)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0114.md
+# dotnet_diagnostic.MA0114.severity = default
+
+# Unknown component parameter (MA0115)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0115.md
+# dotnet_diagnostic.MA0115.severity = default
+
+# Parameters with [SupplyParameterFromQuery] attributes should also be marked as [Parameter] (MA0116)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0116.md
+# dotnet_diagnostic.MA0116.severity = default
+
+# Parameters with [EditorRequired] attributes should also be marked as [Parameter] (MA0117)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0117.md
+# dotnet_diagnostic.MA0117.severity = default
+
+# [JSInvokable] methods must be public (MA0118)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0118.md
+# dotnet_diagnostic.MA0118.severity = default
+
+# JSRuntime must not be used in OnInitialized or OnInitializedAsync (MA0119)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0119.md
+# dotnet_diagnostic.MA0119.severity = default
+
+# Use InvokeVoidAsync when the returned value is not used (MA0120)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0120.md
+# dotnet_diagnostic.MA0120.severity = default
+
+# Do not overwrite parameter value (MA0121)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0121.md
+# dotnet_diagnostic.MA0121.severity = default
+
+# Parameters with [SupplyParameterFromQuery] attributes are only valid in routable components (@page) (MA0122)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0122.md
+# dotnet_diagnostic.MA0122.severity = default
+
+# Sequence number must be a constant (MA0123)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0123.md
+# dotnet_diagnostic.MA0123.severity = default
+
+# Log parameter type is not valid (MA0124)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0124.md
+# dotnet_diagnostic.MA0124.severity = default
+
+# The list of log parameter types contains an invalid type (MA0125)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0125.md
+# dotnet_diagnostic.MA0125.severity = default
+
+# The list of log parameter types contains a duplicate (MA0126)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0126.md
+# dotnet_diagnostic.MA0126.severity = default
+
+# Use String.Equals instead of is pattern (MA0127)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0127.md
+# dotnet_diagnostic.MA0127.severity = default
+
+# Use 'is' operator instead of SequenceEqual (MA0128)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0128.md
+# dotnet_diagnostic.MA0128.severity = default
+
+# Await task in using statement (MA0129)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0129.md
+# dotnet_diagnostic.MA0129.severity = default
+
+# GetType() should not be used on System.Type instances (MA0130)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0130.md
+# dotnet_diagnostic.MA0130.severity = default
+
+# ArgumentNullException.ThrowIfNull should not be used with non-nullable types (MA0131)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0131.md
+# dotnet_diagnostic.MA0131.severity = default
+
+# Do not convert implicitly to DateTimeOffset (MA0132)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0132.md
+# dotnet_diagnostic.MA0132.severity = default
+
+# Use DateTimeOffset instead of relying on the implicit conversion (MA0133)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0133.md
+# dotnet_diagnostic.MA0133.severity = default
+
+# Observe result of async calls (MA0134)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md
+# dotnet_diagnostic.MA0134.severity = default
+
+# The log parameter has no configured type (MA0135)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0135.md
+# dotnet_diagnostic.MA0135.severity = default
+
+# Raw String contains an implicit end of line character (MA0136)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0136.md
 dotnet_diagnostic.MA0136.severity = silent
-# MA0137: Use 'Async' suffix when a method returns an awaitable type
-dotnet_diagnostic.MA0137.severity = none
-# MA0138: Do not use 'Async' suffix when a method does not return an awaitable type
-dotnet_diagnostic.MA0138.severity = none
-# MA0139: Log Parameter type is not valid
-dotnet_diagnostic.MA0139.severity = warning
 
-# MA0140: Both if and else branch have identical code
-dotnet_diagnostic.MA0140.severity = warning
-# MA0141: Use pattern matching instead of inequality operators for null check
-dotnet_diagnostic.MA0141.severity = none
-# MA0142: Use pattern matching instead of equality operators for null check
-dotnet_diagnostic.MA0142.severity = none
-# MA0143: Primary constructor parameters should be readonly
-dotnet_diagnostic.MA0143.severity = warning
-# MA0144: Use System.OperatingSystem to check the current OS
-dotnet_diagnostic.MA0144.severity = warning
-# MA0145: Signature for [UnsafeAccessorAttribute] method is not valid
-dotnet_diagnostic.MA0145.severity = warning
-# MA0146: Name must be set explicitly on local functions
-dotnet_diagnostic.MA0146.severity = warning
-# MA0147: Avoid async void method for delegate
-dotnet_diagnostic.MA0147.severity = warning
-# MA0148: Use pattern matching instead of equality operators for discrete value
-dotnet_diagnostic.MA0148.severity = none
-# MA0149: Use pattern matching instead of inequality operators for discrete value
-dotnet_diagnostic.MA0149.severity = none
+# Use 'Async' suffix when a method returns an awaitable type (MA0137)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0137.md
+# dotnet_diagnostic.MA0137.severity = default
 
-# MA0150: Do not call the default object.ToString explicitly
-dotnet_diagnostic.MA0150.severity = warning
-# MA0151: DebuggerDisplay must contain valid members
-dotnet_diagnostic.MA0151.severity = warning
-# MA0152: Use Unwrap instead of using await twice
-dotnet_diagnostic.MA0152.severity = suggestion
-# MA0153: Do not log symbols decorated with DataClassificationAttribute directly
-dotnet_diagnostic.MA0153.severity = warning
+# Do not use 'Async' suffix when a method does not return an awaitable type (MA0138)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0138.md
+# dotnet_diagnostic.MA0138.severity = default
+
+# Log parameter type is not valid (MA0139)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0139.md
+# dotnet_diagnostic.MA0139.severity = default
+
+# Both if and else branch have identical code (MA0140)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0140.md
+# dotnet_diagnostic.MA0140.severity = default
+
+# Use pattern matching instead of inequality operators for null check (MA0141)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0141.md
+# dotnet_diagnostic.MA0141.severity = default
+
+# Use pattern matching instead of equality operators for null check (MA0142)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0142.md
+# dotnet_diagnostic.MA0142.severity = default
+
+# Primary constructor parameters should be readonly (MA0143)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0143.md
+# dotnet_diagnostic.MA0143.severity = default
+
+# Use System.OperatingSystem to check the current OS (MA0144)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0144.md
+# dotnet_diagnostic.MA0144.severity = default
+
+# Signature for [UnsafeAccessorAttribute] method is not valid (MA0145)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0145.md
+# dotnet_diagnostic.MA0145.severity = default
+
+# Name must be set explicitly on local functions (MA0146)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0146.md
+# dotnet_diagnostic.MA0146.severity = default
+
+# Avoid async void method for delegate (MA0147)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0147.md
+# dotnet_diagnostic.MA0147.severity = default
+
+# Use pattern matching instead of equality operators for discrete value (MA0148)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0148.md
+# dotnet_diagnostic.MA0148.severity = default
+
+# Use pattern matching instead of inequality operators for discrete value (MA0149)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0149.md
+# dotnet_diagnostic.MA0149.severity = default
+
+# Do not call the default object.ToString explicitly (MA0150)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0150.md
+# dotnet_diagnostic.MA0150.severity = default
+
+# DebuggerDisplay must contain valid members (MA0151)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0151.md
+# dotnet_diagnostic.MA0151.severity = default
+
+# Use Unwrap instead of using await twice (MA0152)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0152.md
+# dotnet_diagnostic.MA0152.severity = default
+
+# Do not log symbols decorated with DataClassificationAttribute directly (MA0153)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0153.md
+# dotnet_diagnostic.MA0153.severity = default
+
+# Use langword in XML comment (MA0154)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0154.md
+# dotnet_diagnostic.MA0154.severity = default
+
+# Do not use async void methods (MA0155)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0155.md
+# dotnet_diagnostic.MA0155.severity = default
+
+# Use 'Async' suffix when a method returns IAsyncEnumerable<T> (MA0156)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0156.md
+# dotnet_diagnostic.MA0156.severity = default
+
+# Do not use 'Async' suffix when a method does not return IAsyncEnumerable<T> (MA0157)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0157.md
+# dotnet_diagnostic.MA0157.severity = default
+
+# Use System.Threading.Lock (MA0158)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0158.md
+# dotnet_diagnostic.MA0158.severity = default
+
+# Use 'Order' instead of 'OrderBy' (MA0159)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0159.md
+# dotnet_diagnostic.MA0159.severity = default
+
+# Use ContainsKey instead of TryGetValue (MA0160)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0160.md
+# dotnet_diagnostic.MA0160.severity = default
+
+# UseShellExecute must be explicitly set (MA0161)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0161.md
+# dotnet_diagnostic.MA0161.severity = default
+
+# Use Process.Start overload with ProcessStartInfo (MA0162)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0162.md
+# dotnet_diagnostic.MA0162.severity = default
+
+# UseShellExecute must be false when redirecting standard input or output (MA0163)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0163.md
+# dotnet_diagnostic.MA0163.severity = default
+
+# Use parentheses to make not pattern clearer (MA0164)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0164.md
+# dotnet_diagnostic.MA0164.severity = default
+
+# Make interpolated string (MA0165)
+# https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0165.md
+dotnet_diagnostic.MA0165.severity = silent
+
+##########################################
+# ErrorProne NET Core Analyzers
+# https://github.com/SergeyTeplyakov/ErrorProne.NET
+##########################################
+
+# EPC11 - Suspicious equality implementation
+# dotnet_diagnostic.EPC11.severity = default
+
+# EPC12 - Suspicious exception handling: only '' is observed in the catch block
+# dotnet_diagnostic.EPC12.severity = default
+
+# EPC13 - Suspicious unobserved result
+# dotnet_diagnostic.EPC13.severity = default
+
+# EPC14 - ConfigureAwait(false) is redundant
+# dotnet_diagnostic.EPC14.severity = default
+
+# EPC15 - ConfigureAwait(false) must be used
+# dotnet_diagnostic.EPC15.severity = default
+
+# EPC16 - Awaiting a result of a null-conditional expression will cause NullReferenceException
+# dotnet_diagnostic.EPC16.severity = default
+
+# EPC17 - Avoid async-void delegates
+# dotnet_diagnostic.EPC17.severity = default
+
+# EPC18 - A task instance is implicitly converted to a string
+# dotnet_diagnostic.EPC18.severity = default
+
+# EPC19 - Observe and Dispose a 'CancellationTokenRegistration' to avoid memory leaks
+# dotnet_diagnostic.EPC19.severity = default
+
+# EPC20 - Avoid using default ToString implementation
+# dotnet_diagnostic.EPC20.severity = default
+
+# EPC23 - Avoid using Enumerable.Contains on HashSet<T>
+# dotnet_diagnostic.EPC23.severity = default
+
+# EPC24 - A hash table "unfriendly" type is used as the key in a hash table
+# dotnet_diagnostic.EPC24.severity = default
+
+# EPC25 - Avoid using default Equals or HashCode implementation from structs
+# dotnet_diagnostic.EPC25.severity = default
+
+# EPC26 - Do not use tasks in using block
+# dotnet_diagnostic.EPC26.severity = default
+
+# ERP021 - Incorrect exception propagation
+# dotnet_diagnostic.ERP021.severity = default
+
+# ERP022 - swallows an unobserved exception
+# dotnet_diagnostic.ERP022.severity = default
+
+# ERP031 - The API is not thread-safe
+# dotnet_diagnostic.ERP031.severity = default
+
+# ERP041 - EventSource class should be sealed
+# dotnet_diagnostic.ERP041.severity = default
+
+# ERP042 - EventSource implementation is not correct
+# dotnet_diagnostic.ERP042.severity = default
+
+##########################################
+# ErrorProne NET Struct Analyzers
+# https://github.com/SergeyTeplyakov/ErrorProne.NET
+##########################################
+
+# EPS01 - A struct can be made readonly
+# Crash with Record structs https://github.com/SergeyTeplyakov/ErrorProne.NET/issues/263
+dotnet_diagnostic.EPS01.severity = none
+
+# EPS05 - Use in-modifier for a readonly struct
+# dotnet_diagnostic.EPS05.severity = default
+
+# EPS06 - An operation causes a hidden struct copy
+# dotnet_diagnostic.EPS06.severity = default
+
+# EPS09 - Pass an argument for an 'in' parameter explicitly
+# dotnet_diagnostic.EPS09.severity = default
+
+# EPS10 - Do not construct non-defaultable struct with 'default' expression
+# dotnet_diagnostic.EPS10.severity = default
+
+# EPS11 - Do not embed non-defaultable structs into another structs
+# dotnet_diagnostic.EPS11.severity = default
+
+# EPS12 - A struct member can be made readonly
+# dotnet_diagnostic.EPS12.severity = default
+
+# EPS13 - A non-defaultable struct must declare a constructor
+# dotnet_diagnostic.EPS13.severity = default

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors></WarningsAsErrors>
-    <WarningsNotAsErrors>MA0026</WarningsNotAsErrors>
+    <WarningsNotAsErrors>MA0026;MA0051;NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/src/Vectron.Extensions.Hosting/IScopeLifeTime.cs
+++ b/src/Vectron.Extensions.Hosting/IScopeLifeTime.cs
@@ -8,10 +8,10 @@ public interface IScopeLifeTime
     /// <summary>
     /// An event that is triggered when a scope is created.
     /// </summary>
-    event EventHandler<ScopeChangedEventArgs>? ScopeCreated;
+    public event EventHandler<ScopeChangedEventArgs>? ScopeCreated;
 
     /// <summary>
     /// An event that is triggered when a scope is being destroyed.
     /// </summary>
-    event EventHandler<ScopeChangedEventArgs>? ScopeDestroying;
+    public event EventHandler<ScopeChangedEventArgs>? ScopeDestroying;
 }

--- a/src/Vectron.Extensions.Hosting/IScopedHost.cs
+++ b/src/Vectron.Extensions.Hosting/IScopedHost.cs
@@ -6,26 +6,30 @@ namespace Vectron.Extensions.Hosting;
 public interface IScopedHost
 {
     /// <summary>
-    /// Gets the services configured for the program />).
+    /// Gets the services configured for the program /&gt;).
     /// </summary>
-    IServiceProvider Services
+    public IServiceProvider Services
     {
         get;
     }
 
     /// <summary>
-    /// Starts the <see cref="IScopedHostedService"/> objects configured for the program. The application
-    /// will run until interrupted or until <see cref="IScopedHostScopeLifetime.StopScope()"/>
-    /// is called.
+    /// Starts the <see cref="IScopedHostedService"/> objects configured for the program. The
+    /// application will run until interrupted or until <see
+    /// cref="IScopedHostScopeLifetime.StopScope()"/> is called.
     /// </summary>
     /// <param name="cancellationToken">Used to abort program start.</param>
-    /// <returns>A <see cref="Task"/> that will be completed when the <see cref="IScopedHost"/> starts.</returns>
-    Task StartAsync(CancellationToken cancellationToken = default);
+    /// <returns>
+    /// A <see cref="Task"/> that will be completed when the <see cref="IScopedHost"/> starts.
+    /// </returns>
+    public Task StartAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Attempts to gracefully stop the program.
     /// </summary>
     /// <param name="cancellationToken">Used to indicate when stop should no longer be graceful.</param>
-    /// <returns>A <see cref="Task"/> that will be completed when the <see cref="IScopedHost"/> stops.</returns>
-    Task StopAsync(CancellationToken cancellationToken = default);
+    /// <returns>
+    /// A <see cref="Task"/> that will be completed when the <see cref="IScopedHost"/> stops.
+    /// </returns>
+    public Task StopAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Vectron.Extensions.Hosting/IScopedHostFactory.cs
+++ b/src/Vectron.Extensions.Hosting/IScopedHostFactory.cs
@@ -21,5 +21,5 @@ public interface IScopedHostFactory
     /// <param name="setupAction">A function that will be run after the <see cref="IServiceScope"/> is created, but before the <see cref="IScopedHost"/> is started.</param>
     /// <param name="cancellationToken">The token to trigger shutdown.</param>
     /// <returns>A <see cref="Task"/> that will be completed when the <see cref="IScopedHost"/> stops.</returns>
-    Task RunScopedHostAsync(SetupScopeFunc setupAction, CancellationToken cancellationToken);
+    public Task RunScopedHostAsync(SetupScopeFunc setupAction, CancellationToken cancellationToken);
 }

--- a/src/Vectron.Extensions.Hosting/IScopedHostLifetime.cs
+++ b/src/Vectron.Extensions.Hosting/IScopedHostLifetime.cs
@@ -10,7 +10,7 @@ public interface IScopedHostLifetime
     /// </summary>
     /// <param name="cancellationToken">Used to indicate when stop should no longer be graceful.</param>
     /// <returns>A <see cref="Task"/>.</returns>
-    Task StopAsync(CancellationToken cancellationToken);
+    public Task StopAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Called at the start of <see cref="IScopedHost.StartAsync(CancellationToken)"/> which will wait until it's complete before
@@ -18,5 +18,5 @@ public interface IScopedHostLifetime
     /// </summary>
     /// <param name="cancellationToken">Used to abort program start.</param>
     /// <returns>A <see cref="Task"/>.</returns>
-    Task WaitForStartAsync(CancellationToken cancellationToken);
+    public Task WaitForStartAsync(CancellationToken cancellationToken);
 }

--- a/src/Vectron.Extensions.Hosting/IScopedHostScopeLifetime.cs
+++ b/src/Vectron.Extensions.Hosting/IScopedHostScopeLifetime.cs
@@ -8,7 +8,7 @@ public interface IScopedHostScopeLifetime
     /// <summary>
     /// Gets a <see cref="CancellationToken"/> that is triggered when the scope host has fully started.
     /// </summary>
-    CancellationToken ScopeStarted
+    public CancellationToken ScopeStarted
     {
         get;
     }
@@ -17,7 +17,7 @@ public interface IScopedHostScopeLifetime
     /// Gets a <see cref="CancellationToken"/> that is Triggered when the scope host has completed a
     /// graceful shutdown. The scope will not exit until all callbacks registered on this token have completed.
     /// </summary>
-    CancellationToken ScopeStopped
+    public CancellationToken ScopeStopped
     {
         get;
     }
@@ -26,7 +26,7 @@ public interface IScopedHostScopeLifetime
     /// Gets a <see cref="CancellationToken"/> that is Triggered when the scope host is starting a
     /// graceful shutdown. Shutdown will block until all callbacks registered on this token have completed.
     /// </summary>
-    CancellationToken ScopeStopping
+    public CancellationToken ScopeStopping
     {
         get;
     }
@@ -34,5 +34,5 @@ public interface IScopedHostScopeLifetime
     /// <summary>
     /// Requests termination of the current scope.
     /// </summary>
-    void StopScope();
+    public void StopScope();
 }

--- a/src/Vectron.Extensions.Hosting/IScopedHostedLifecycleService.cs
+++ b/src/Vectron.Extensions.Hosting/IScopedHostedLifecycleService.cs
@@ -1,9 +1,8 @@
 namespace Vectron.Extensions.Hosting;
 
 /// <summary>
-/// Defines methods that are run before or after
-/// <see cref="IScopedHostedService.StartAsync(CancellationToken)"/> and
-/// <see cref="IScopedHostedService.StopAsync(CancellationToken)"/>.
+/// Defines methods that are run before or after <see
+/// cref="IScopedHostedService.StartAsync(CancellationToken)"/> and <see cref="IScopedHostedService.StopAsync(CancellationToken)"/>.
 /// </summary>
 public interface IScopedHostedLifecycleService : IScopedHostedService
 {
@@ -12,26 +11,26 @@ public interface IScopedHostedLifecycleService : IScopedHostedService
     /// </summary>
     /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-    Task StartedAsync(CancellationToken cancellationToken);
+    public Task StartedAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Triggered before <see cref="IScopedHostedService.StartAsync(CancellationToken)"/>.
     /// </summary>
     /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-    Task StartingAsync(CancellationToken cancellationToken);
+    public Task StartingAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Triggered after <see cref="IScopedHostedService.StopAsync(CancellationToken)"/>.
     /// </summary>
     /// <param name="cancellationToken">Indicates that the stop process has been aborted.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-    Task StoppedAsync(CancellationToken cancellationToken);
+    public Task StoppedAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Triggered before <see cref="IScopedHostedService.StopAsync(CancellationToken)"/>.
     /// </summary>
     /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-    Task StoppingAsync(CancellationToken cancellationToken);
+    public Task StoppingAsync(CancellationToken cancellationToken);
 }

--- a/src/Vectron.Extensions.Hosting/IScopedHostedService.cs
+++ b/src/Vectron.Extensions.Hosting/IScopedHostedService.cs
@@ -10,12 +10,12 @@ public interface IScopedHostedService
     /// </summary>
     /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous Start operation.</returns>
-    Task StartAsync(CancellationToken cancellationToken);
+    public Task StartAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Triggered when the application host is performing a graceful shutdown.
     /// </summary>
     /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous Stop operation.</returns>
-    Task StopAsync(CancellationToken cancellationToken);
+    public Task StopAsync(CancellationToken cancellationToken);
 }

--- a/src/Vectron.Extensions.Hosting/Internal/ScopedHostFactory.cs
+++ b/src/Vectron.Extensions.Hosting/Internal/ScopedHostFactory.cs
@@ -7,7 +7,7 @@ namespace Vectron.Extensions.Hosting.Internal;
 /// </summary>
 /// <param name="scopeFactory">The <see cref="IServiceScopeFactory"/>.</param>
 /// <param name="scopeLifeTime">The <see cref="IScopeLifeTime"/>.</param>
-internal class ScopedHostFactory(IServiceScopeFactory scopeFactory, IScopeLifeTime scopeLifeTime) : IScopedHostFactory
+internal sealed class ScopedHostFactory(IServiceScopeFactory scopeFactory, IScopeLifeTime scopeLifeTime) : IScopedHostFactory
 {
     private readonly ScopeLifeTime scopeLifeTime = scopeLifeTime as ScopeLifeTime
         ?? throw new InvalidOperationException("Replacing IScopeLifeTime is not supported.");


### PR DESCRIPTION
#### PR Classification
Update to coding standards and configurations in the project.

#### PR Summary
This pull request updates the `.editorconfig` file to version 9.0.0, introducing new coding standards and naming conventions for C# and Visual Basic projects. It also modifies the `Directory.Build.props` file to adjust warning settings.
- `.editorconfig`: Updated to version 9.0.0 with new settings for code style, naming conventions, and analysis options.
- `.editorconfig`: Retained `trim_trailing_whitespace` as `true` and set `end_of_line` to `lf`.
- `.editorconfig`: Added new sections for spell-checking rules and various analyzers.
- `.editorconfig`: Updated naming conventions to require "Async" suffix for async methods.
- `Directory.Build.props`: Added `MA0051`, `NU1901`, `NU1902`, `NU1903`, and `NU1904` to `WarningsNotAsErrors`.
