### PR TITLE
Update .NET versions to include 9.0.x support

### DIFF
--- a/.github/workflows/BuildTestDeploy.yml
+++ b/.github/workflows/BuildTestDeploy.yml
@@ -39,9 +39,8 @@ jobs:
     with:
       os: ${{ matrix.os }}
       dotnet_version: |
-        6.0.x
-        7.0.x
         8.0.x
+        9.0.x
       solution_file: Vectron.Extensions.Hosting.sln
 
   call-deploy:
@@ -52,9 +51,8 @@ jobs:
     with:
       os: ubuntu-latest
       dotnet_version: |
-        6.0.x
-        7.0.x
         8.0.x
+        9.0.x
       solution_file: Vectron.Extensions.Hosting.sln
     secrets:
       NUGET_KEY: ${{ secrets.NUGET_KEY }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net6.0; net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0; net9.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
     <Deterministic>true</Deterministic>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
- Updated `BuildTestDeploy.yml` to support .NET 9.0.x in build and deploy jobs, removing older versions (6.0.x, 7.0.x, 8.0.x).
- Modified `Directory.Build.props` to target frameworks `net8.0` and `net9.0`, replacing `net6.0` and `net8.0`.